### PR TITLE
Remove first two lines from `itemdef.csv` files

### DIFF
--- a/business/agriculture/livestock/entericfermentation/itemdef.csv
+++ b/business/agriculture/livestock/entericfermentation/itemdef.csv
@@ -1,5 +1,3 @@
-name,Livestock Enteric Fermentation
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Livestock type,livestockType,TEXT,true,true,,,,
 Geographic region,region,TEXT,true,true,,,,

--- a/business/agriculture/livestock/manure/ch4/cattleandswine/itemdef.csv
+++ b/business/agriculture/livestock/manure/ch4/cattleandswine/itemdef.csv
@@ -1,5 +1,3 @@
-name,Manure methane cattle and swine
-algFile,default.js
 name,path,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Livestock type,livestockType,TEXT,true,true,,,,
 Geographic region,region,TEXT,true,true,,,,

--- a/business/agriculture/livestock/manure/ch4/other/itemdef.csv
+++ b/business/agriculture/livestock/manure/ch4/other/itemdef.csv
@@ -1,5 +1,3 @@
-name,Manure methane other
-algFile,default.js
 name,path,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Livestock type,livestockType,TEXT,true,true,,,,
 Geographic context,geographicContext,TEXT,true,true,,,,

--- a/business/agriculture/livestock/manure/ch4/poultry/itemdef.csv
+++ b/business/agriculture/livestock/manure/ch4/poultry/itemdef.csv
@@ -1,5 +1,3 @@
-name,Manure methane poultry
-algFile,default.js
 name,path,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Geographic context,geographicContext,TEXT,true,true,,,,
 Poultry type,poultryType,TEXT,true,true,,,,

--- a/business/agriculture/livestock/manure/n2o/cattleandswine/itemdef.csv
+++ b/business/agriculture/livestock/manure/n2o/cattleandswine/itemdef.csv
@@ -1,5 +1,3 @@
-name,Manure N2O cattle and swine
-algFile,default.js
 name,path,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Region,region,TEXT,true,true,,,,
 Livestock type,livestockType,TEXT,true,true,,,,

--- a/business/agriculture/livestock/manure/n2o/furbearing/itemdef.csv
+++ b/business/agriculture/livestock/manure/n2o/furbearing/itemdef.csv
@@ -1,5 +1,3 @@
-name,Manure N2O fur
-algFile,default.js
 name,path,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Livestock type,livestockType,TEXT,true,true,,,,
 Management type,managementType,TEXT,true,true,,,,

--- a/business/agriculture/livestock/manure/n2o/other/itemdef.csv
+++ b/business/agriculture/livestock/manure/n2o/other/itemdef.csv
@@ -1,5 +1,3 @@
-name,Manure N2O other
-algFile,default.js
 name,path,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Region,region,TEXT,true,true,,,,
 Livestock type,livestockType,TEXT,true,true,,,,

--- a/business/agriculture/livestock/manure/n2o/poultry/itemdef.csv
+++ b/business/agriculture/livestock/manure/n2o/poultry/itemdef.csv
@@ -1,5 +1,3 @@
-name,Manure N2O poultry
-algFile,default.js
 name,path,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Region,region,TEXT,true,true,,,,
 Poultry subtype,poultrySubtype,TEXT,true,true,,,,

--- a/business/agriculture/rice/itemdef.csv
+++ b/business/agriculture/rice/itemdef.csv
@@ -1,5 +1,3 @@
-name,Rice cultivation
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Rice cultivation system,system,TEXT,true,true,,,,
 Drainage regime,drainage,TEXT,true,true,,,,

--- a/business/agriculture/soil/inputs/animal/itemdef.csv
+++ b/business/agriculture/soil/inputs/animal/itemdef.csv
@@ -1,5 +1,3 @@
-name,Soil N2O from animal inputs
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 livestock type,type,TEXT,true,true,,,,
 Direct urine and dung-N to N2O-N conversion factor,massPerMass,DECIMAL,true,false,kg,kg,,

--- a/business/agriculture/soil/inputs/other/itemdef.csv
+++ b/business/agriculture/soil/inputs/other/itemdef.csv
@@ -1,5 +1,3 @@
-name,Soil N2O from other inputs
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Treatment type,type,TEXT,true,true,,,,
 Treatment subtype,subtype,TEXT,true,true,,,,

--- a/business/agriculture/soil/lime/itemdef.csv
+++ b/business/agriculture/soil/lime/itemdef.csv
@@ -1,5 +1,3 @@
-name,Soil liming
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Carbonate mineral used in liming,type,TEXT,true,true,,,,
 Carbon content of carbonate,massPerMass,DECIMAL,true,false,t,t,,

--- a/business/agriculture/soil/organic/itemdef.csv
+++ b/business/agriculture/soil/organic/itemdef.csv
@@ -1,5 +1,3 @@
-name,Soil N2O from managed organic soils
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Climatic context,context,TEXT,true,true,,,,
 Land use type,type,TEXT,true,true,,,,

--- a/business/agriculture/soil/urea/itemdef.csv
+++ b/business/agriculture/soil/urea/itemdef.csv
@@ -1,5 +1,3 @@
-name,Soil urea application
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Additive type,type,TEXT,true,true,,,,
 Carbon content of urea,massPerMass,DECIMAL,true,false,t,t,,

--- a/business/benchmark/cdp/itemdef.csv
+++ b/business/benchmark/cdp/itemdef.csv
@@ -1,5 +1,3 @@
-name,CDP emissions and financial metrics
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Company,company,TEXT,true,true,,,,
 Country,country,TEXT,true,true,,,,

--- a/business/benchmark/crc/itemdef.csv
+++ b/business/benchmark/crc/itemdef.csv
@@ -1,5 +1,3 @@
-name,Carbon Reduction Commitment League Table
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Organization name,organizationName,TEXT,true,true,,,,
 Registration number,registrationNumber,TEXT,true,false,,,,

--- a/business/buildings/hotel/generic/itemdef.csv
+++ b/business/buildings/hotel/generic/itemdef.csv
@@ -1,5 +1,3 @@
-name,Hotel Stay
-algFile,algorithm.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 CO2perPerson,CO2perPerson,DECIMAL,true,false,,,,
 Source,source,TEXT,true,false,,,,

--- a/business/energy/chp/defra/itemdef.csv
+++ b/business/energy/chp/defra/itemdef.csv
@@ -1,5 +1,3 @@
-name,DEFRA CHP Energy
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of service,type,TEXT,true,true,,,,
 Total plant emissions,plantEmissions,DECIMAL,false,false,kg,,,

--- a/business/energy/chp/ghgp/itemdef.csv
+++ b/business/energy/chp/ghgp/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGP CHP
-algfile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Country,country,TEXT,true,true,,,,
 GHG programme,ghgProgramme,TEXT,true,true,,,,

--- a/business/energy/electricity/china/byGrid/itemdef.csv
+++ b/business/energy/electricity/china/byGrid/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGP Electricity China by grid
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Grid Name,gridName,TEXT,true,true,,,,
 Energy per Time,energyPerTime,DECIMAL,false,false,kWh,year,,

--- a/business/energy/electricity/china/byProvince/itemdef.csv
+++ b/business/energy/electricity/china/byProvince/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGP Electricity China by province
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Province Name,provinceName,TEXT,true,true,,,,
 Grid Name,gridName,TEXT,true,false,,,,

--- a/business/energy/electricity/coal/itemdef.csv
+++ b/business/energy/electricity/coal/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHG Electricity Coal
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Country,country,TEXT,true,true,,,,
 Energy Per Time,energyPerTime,DECIMAL,false,false,kWh,year,,

--- a/business/energy/electricity/defra/international/itemdef.csv
+++ b/business/energy/electricity/defra/international/itemdef.csv
@@ -1,5 +1,3 @@
-name,DEFRA International electricity
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Country,country,TEXT,true,true,,,,
 Type of process,type,TEXT,true,true,,,,

--- a/business/energy/electricity/defra/uk/itemdef.csv
+++ b/business/energy/electricity/defra/uk/itemdef.csv
@@ -1,5 +1,3 @@
-name,DEFRA UK electricity
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of activity,type,TEXT,true,true,,,,
 Type of emission,emission,TEXT,true,true,,,,

--- a/business/energy/electricity/epa/egrid/itemdef.csv
+++ b/business/energy/electricity/epa/egrid/itemdef.csv
@@ -1,5 +1,3 @@
-name,EPA eGrid regions
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Grid subregion,region,TEXT,true,true,,,,
 Emission type,type,TEXT,true,true,,,,

--- a/business/energy/electricity/epa/nerc/itemdef.csv
+++ b/business/energy/electricity/epa/nerc/itemdef.csv
@@ -1,5 +1,3 @@
-name,EPA NERC regions
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Grid subregion,region,TEXT,true,true,,,,
 Emission type,type,TEXT,true,true,,,,

--- a/business/energy/electricity/epa/pca/itemdef.csv
+++ b/business/energy/electricity/epa/pca/itemdef.csv
@@ -1,5 +1,3 @@
-name,EPA eGrid by Power Control Area
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Power Control Area,area,TEXT,true,true,,,,
 Emission type,type,TEXT,true,true,,,,

--- a/business/energy/electricity/epa/state/itemdef.csv
+++ b/business/energy/electricity/epa/state/itemdef.csv
@@ -1,5 +1,3 @@
-name,EPA eGrid by state
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 State,state,TEXT,true,true,,,,
 Emission type,type,TEXT,true,true,,,,

--- a/business/energy/electricity/epa/transmission/itemdef.csv
+++ b/business/energy/electricity/epa/transmission/itemdef.csv
@@ -1,5 +1,3 @@
-name,EPA eGrid transmission losses
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Grid region,region,TEXT,true,true,,,,
 Grid region name,name,TEXT,true,false,,,,

--- a/business/energy/electricity/gas/itemdef.csv
+++ b/business/energy/electricity/gas/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHG Electricity Gas
-aglFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Country,country,TEXT,true,true,,,,
 Energy Per Time,energyPerTime,DECIMAL,false,false,kWh,year,,

--- a/business/energy/electricity/grid/itemdef.csv
+++ b/business/energy/electricity/grid/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGP international grid electricity
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Country,country,TEXT,true,true,,,,
 Mass CO2 per Energy,massCO2PerEnergy,DECIMAL,true,false,kg,kWh,,

--- a/business/energy/electricity/india/byGrid/itemdef.csv
+++ b/business/energy/electricity/india/byGrid/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGP Electricity India by grid
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Grid Name,gridName,TEXT,true,true,,,,
 Energy per Time,energyPerTime,DECIMAL,false,false,kWh,year,,

--- a/business/energy/electricity/india/byState/itemdef.csv
+++ b/business/energy/electricity/india/byState/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGP Electricity India by province
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 State Name,stateName,TEXT,true,true,,,,
 Grid Name,gridName,TEXT,true,false,,,,

--- a/business/energy/electricity/itemdef.csv
+++ b/business/energy/electricity/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGElectricity
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Country,country,TEXT,true,true,,,,
 Energy per Time,energyPerTime,DECIMAL,false,false,kWh,year,,

--- a/business/energy/electricity/nordic/nationaldom/itemdef.csv
+++ b/business/energy/electricity/nordic/nationaldom/itemdef.csv
@@ -1,5 +1,3 @@
-name,Electricity Disclosure - National Domain
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Year,year,INTEGER,true,true,,,,
 Country,country,TEXT,true,true,,,,

--- a/business/energy/electricity/nordic/nordicdom/itemdef.csv
+++ b/business/energy/electricity/nordic/nordicdom/itemdef.csv
@@ -1,5 +1,3 @@
-name,Electricity Disclosure - Nordic Domain
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Year,year,TEXT,true,true,,,,
 Country,country,TEXT,true,true,,,,

--- a/business/energy/electricity/oil/itemdef.csv
+++ b/business/energy/electricity/oil/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHG Electricity Oil
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Country,country,TEXT,true,true,,,,
 Energy Per Time,energyPerTime,DECIMAL,false,false,kWh,year,,

--- a/business/energy/fuel/defra/itemdef.csv
+++ b/business/energy/fuel/defra/itemdef.csv
@@ -1,5 +1,3 @@
-name,Fuel DEFRA
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel Type,fuel,TEXT,true,true,,,,
 Net or Gross CV Basis,netOrGross,TEXT,true,true,,,,

--- a/business/energy/fuel/defra/lifecycle/biofuel/itemdef.csv
+++ b/business/energy/fuel/defra/lifecycle/biofuel/itemdef.csv
@@ -1,5 +1,3 @@
-name,Biofuel life-cycle
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Mass CO2 Equivalent per Biofuel Mass,massCO2ePerBiofuelMass,DECIMAL,true,false,kg,kg,,

--- a/business/energy/fuel/defra/lifecycle/biomass/itemdef.csv
+++ b/business/energy/fuel/defra/lifecycle/biomass/itemdef.csv
@@ -1,5 +1,3 @@
-name,Biomass life-cycle
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Mass CO2 Equivalent per Mass of Biomass,kgCO2ePerTonne,DECIMAL,true,false,kg,t,,

--- a/business/energy/fuel/ghgp/india/itemdef.csv
+++ b/business/energy/fuel/ghgp/india/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGP India Biomass
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Net Calorific Value,netCalorificValue,DECIMAL,true,false,GJ,t,,

--- a/business/energy/stationaryCombustion/carbon/itemdef.csv
+++ b/business/energy/stationaryCombustion/carbon/itemdef.csv
@@ -1,5 +1,3 @@
-name,Stationary combustion by carbon content
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of fuel,type,TEXT,true,true,,,,
 Subtype of fuel,subtype,TEXT,true,true,,,,

--- a/business/energy/stationaryCombustion/cems/itemdef.csv
+++ b/business/energy/stationaryCombustion/cems/itemdef.csv
@@ -1,5 +1,3 @@
-name,Continuous emissions monitoring system
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of fuel,fuel,TEXT,true,true,,,,
 Subtype of fuel,subtype,TEXT,true,true,,,,

--- a/business/energy/stationaryCombustion/crc/itemdef.csv
+++ b/business/energy/stationaryCombustion/crc/itemdef.csv
@@ -1,5 +1,3 @@
-name,Carbon Reduction Commitment
-algFile,default.js
 name,path,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel,fuel,TEXT,true,true,,,,
 Mass CO2 per energy,massCO2PerEnergy,DECIMAL,true,false,kg,kWh,,

--- a/business/energy/stationaryCombustion/defra/biofuel/itemdef.csv
+++ b/business/energy/stationaryCombustion/defra/biofuel/itemdef.csv
@@ -1,5 +1,3 @@
-name,DEFRA biofuels
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of fuel,fuel,TEXT,true,true,,,,
 Direct CO2e per unit volume,massDirectCO2ePerVolume,DECIMAL,true,false,kg,L,,

--- a/business/energy/stationaryCombustion/defra/biomass/itemdef.csv
+++ b/business/energy/stationaryCombustion/defra/biomass/itemdef.csv
@@ -1,5 +1,3 @@
-name,DEFRA biomass fuel
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of fuel,fuel,TEXT,true,true,,,,
 Direct biogenic CO2 emissions per mass,massBiogenicCO2ePerMass,DECIMAL,true,false,kg,t,,

--- a/business/energy/stationaryCombustion/defra/blends/conventional/itemdef.csv
+++ b/business/energy/stationaryCombustion/defra/blends/conventional/itemdef.csv
@@ -1,5 +1,3 @@
-name,DEFRA conventional fuels for biofuel blends
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of fuel,fuel,TEXT,true,true,,,,
 Direct CO2e per unit volume,massDirectCO2ePerVolume,DECIMAL,true,false,kg,L,,

--- a/business/energy/stationaryCombustion/defra/blends/itemdef.csv
+++ b/business/energy/stationaryCombustion/defra/blends/itemdef.csv
@@ -1,5 +1,3 @@
-name,DEFRA biofuel blends
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of fuel,fuel,TEXT,true,true,,,,
 Mass consumed,mass,DECIMAL,false,false,kg,,,

--- a/business/energy/stationaryCombustion/defra/energy/itemdef.csv
+++ b/business/energy/stationaryCombustion/defra/energy/itemdef.csv
@@ -1,5 +1,3 @@
-name,DEFRA stationary combustion by energy
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of fuel,fuel,TEXT,true,true,,,,
 Calorific basis,basis,TEXT,true,true,,,,

--- a/business/energy/stationaryCombustion/defra/fuelproperties/itemdef.csv
+++ b/business/energy/stationaryCombustion/defra/fuelproperties/itemdef.csv
@@ -1,5 +1,3 @@
-name,DEFRA fuel properties
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of fuel,fuel,TEXT,true,true,,,,
 Net calorific (lower heating) value,netEnergyPerMass,DECIMAL,true,false,GJ,t,,

--- a/business/energy/stationaryCombustion/defra/mass/itemdef.csv
+++ b/business/energy/stationaryCombustion/defra/mass/itemdef.csv
@@ -1,5 +1,3 @@
-name,DEFRA stationary combustion by mass
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of fuel,fuel,TEXT,true,true,,,,
 Direct CO2 emissions factor,massCO2PerMass,DECIMAL,true,false,kg,t,,

--- a/business/energy/stationaryCombustion/defra/volume/itemdef.csv
+++ b/business/energy/stationaryCombustion/defra/volume/itemdef.csv
@@ -1,5 +1,3 @@
-name,DEFRA stationary combustion by volume
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of fuel,fuel,TEXT,true,true,,,,
 Direct CO2 emissions factor,massCO2PerVolume,DECIMAL,true,false,kg,L,,

--- a/business/energy/stationaryCombustion/epa/ch4andn2ofactors/itemdef.csv
+++ b/business/energy/stationaryCombustion/epa/ch4andn2ofactors/itemdef.csv
@@ -1,5 +1,3 @@
-name,Stationary combustion EPA - CH4 and N2O factors
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,type,TEXT,true,true,,,,
 Burning context,context,TEXT,true,true,,,,

--- a/business/energy/stationaryCombustion/epa/coal/itemdef.csv
+++ b/business/energy/stationaryCombustion/epa/coal/itemdef.csv
@@ -1,5 +1,3 @@
-name,Stationary combustion of coal EPA
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,type,TEXT,true,true,,,,
 Heating value of fuel,energyPerMass,DECIMAL,true,false,MBTU_FiftyNineF,ton_us,,

--- a/business/energy/stationaryCombustion/epa/gas/itemdef.csv
+++ b/business/energy/stationaryCombustion/epa/gas/itemdef.csv
@@ -1,5 +1,3 @@
-name,Stationary combustion of gas EPA
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,type,TEXT,true,true,,,,
 Fuel subtype,subtype,TEXT,true,true,,,,

--- a/business/energy/stationaryCombustion/epa/petroleum/itemdef.csv
+++ b/business/energy/stationaryCombustion/epa/petroleum/itemdef.csv
@@ -1,5 +1,3 @@
-name,Stationary combustion of petroleum products EPA
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,type,TEXT,true,true,,,,
 Fuel subtype,subtype,TEXT,true,true,,,,

--- a/business/energy/stationaryCombustion/epa/tires/itemdef.csv
+++ b/business/energy/stationaryCombustion/epa/tires/itemdef.csv
@@ -1,5 +1,3 @@
-name,Stationary combustion of tires EPA
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,type,TEXT,true,true,,,,
 Heating value of fuel,energyPerMass,DECIMAL,true,false,MBTU_FiftyNineF,ton_us,,

--- a/business/energy/stationaryCombustion/epa/wood/itemdef.csv
+++ b/business/energy/stationaryCombustion/epa/wood/itemdef.csv
@@ -1,5 +1,3 @@
-name,Stationary combustion of wood EPA
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,type,TEXT,true,true,,,,
 Fuel subtype,subtype,TEXT,true,true,,,,

--- a/business/energy/stationaryCombustion/itemdef.csv
+++ b/business/energy/stationaryCombustion/itemdef.csv
@@ -1,5 +1,3 @@
-name,stationaryCombustion
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of fuel,fuel,TEXT,true,true,,,,
 Combustion context,context,TEXT,true,true,,,,

--- a/business/energy/us/subregion/itemdef.csv
+++ b/business/energy/us/subregion/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGUSSubregion
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 eGRID Subregion,subregion,TEXT,true,true,,,,
 Energy Per Time,energyPerTime,DECIMAL,false,false,kWh,year,,

--- a/business/processes/carbonates/generic/itemdef.csv
+++ b/business/processes/carbonates/generic/itemdef.csv
@@ -1,5 +1,3 @@
-name,Generic carbonates
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of carbonate,type,TEXT,true,true,,,,
 Form of carbonate,form,TEXT,true,true,,,,

--- a/business/processes/carbonates/specific/itemdef.csv
+++ b/business/processes/carbonates/specific/itemdef.csv
@@ -1,5 +1,3 @@
-name,Miscellaneous carbonate consumption
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of process,type,TEXT,true,true,,,,
 Quantity of calcite/aragonite consumed,massCalcite,DECIMAL,false,false,t,,,

--- a/business/processes/defra/itemdef.csv
+++ b/business/processes/defra/itemdef.csv
@@ -1,5 +1,3 @@
-name,DEFRA Emissions types by industrial process
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Industrial sector,sector,TEXT,true,true,,,,
 Industrial process,process,TEXT,true,true,,,,

--- a/business/processes/flaring/ghgp/itemdef.csv
+++ b/business/processes/flaring/ghgp/itemdef.csv
@@ -1,5 +1,3 @@
-name,Flaring
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of flaring,type,TEXT,true,true,,,,
 Volume of gas flared,volume,DECIMAL,false,false,ft^3,,,

--- a/business/processes/fugitive/methaneflaring/itemdef.csv
+++ b/business/processes/fugitive/methaneflaring/itemdef.csv
@@ -1,5 +1,3 @@
-name,methane flaring
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of flaring,type,TEXT,true,true,,,,
 Volume of methane flared,volumeCH4Flared,DECIMAL,false,false,m^3,year,,

--- a/business/processes/fugitive/mining/surface/itemdef.csv
+++ b/business/processes/fugitive/mining/surface/itemdef.csv
@@ -1,5 +1,3 @@
-name,fugitive surface mining
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Overburden depth,overburdenDepth,TEXT,true,true,,,,
 Mining phase emissions per tonne,volumeCH4PerMassMining,DECIMAL,true,false,m^3,t,,

--- a/business/processes/fugitive/mining/underground/abandoned/defined/itemdef.csv
+++ b/business/processes/fugitive/mining/underground/abandoned/defined/itemdef.csv
@@ -1,5 +1,3 @@
-name,fugitive abandoned mine user defined
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Coal rank,coalRank,TEXT,true,true,,,,
 CH4 emissions rate prior to abandonment,emissionsRate,DECIMAL,false,false,m^3,year,,

--- a/business/processes/fugitive/mining/underground/abandoned/generic/itemdef.csv
+++ b/business/processes/fugitive/mining/underground/abandoned/generic/itemdef.csv
@@ -1,5 +1,3 @@
-name,fugitive abandoned mine generic
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Year of emissions inventory,inventoryYear,INTEGER,true,true,,,,
 Annual CH4 emissions from mines abandoned between 1901 and 1925,volumeCH4PerTime1901to1925,DECIMAL,true,false,m^3,year,,

--- a/business/processes/fugitive/mining/underground/itemdef.csv
+++ b/business/processes/fugitive/mining/underground/itemdef.csv
@@ -1,5 +1,3 @@
-name,fugitive underground mining
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Mine depth,mineDepth,TEXT,true,true,,,,
 Mining phase emissions per tonne,volumeCH4PerMassMining,DECIMAL,true,false,m^3,t,,

--- a/business/processes/fugitive/oilandgas/itemdef.csv
+++ b/business/processes/fugitive/oilandgas/itemdef.csv
@@ -1,5 +1,3 @@
-name,fugitive oil and gas
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Process type,type,TEXT,true,true,,,,
 Process subtype,subType,TEXT,true,true,,,,

--- a/business/processes/lubricants/itemdef.csv
+++ b/business/processes/lubricants/itemdef.csv
@@ -1,5 +1,3 @@
-name,Lubricants
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Lubricant type,type,TEXT,true,true,,,,
 Carbon content,massCarbonPerEnergy,DECIMAL,true,false,kg,GJ,,

--- a/business/processes/production/adipicAcid/itemdef.csv
+++ b/business/processes/production/adipicAcid/itemdef.csv
@@ -1,5 +1,3 @@
-name,Adipic Acid N2O emissions
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Abatement Technology employed,abatementTechnology,TEXT,true,true,,,,
 Quantity of Adipic Acid produced,adipicQuantity,DECIMAL,false,false,kg,,,

--- a/business/processes/production/aluminium/alternative/itemdef.csv
+++ b/business/processes/production/aluminium/alternative/itemdef.csv
@@ -1,5 +1,3 @@
-name,Aluminium Production: Alternative (no anode data)
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Total Pitch Comsumption,pitchQuantity,DECIMAL,false,false,kg,,,
 Percentage Carbon Content of Pitch,carbonPitch,DECIMAL,false,false,,,95,

--- a/business/processes/production/aluminium/coke/itemdef.csv
+++ b/business/processes/production/aluminium/coke/itemdef.csv
@@ -1,5 +1,3 @@
-name,Coke calcination
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Green coke feed,massGreenCoke,DECIMAL,false,false,t,,,

--- a/business/processes/production/aluminium/defaults/itemdef.csv
+++ b/business/processes/production/aluminium/defaults/itemdef.csv
@@ -1,5 +1,3 @@
-name,Aluminium Production: Defaults only
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of cell technology,processType,TEXT,true,true,,,,
 Quantity of aluminium produced,aluminiumQuantity,DECIMAL,false,false,kg,,,

--- a/business/processes/production/aluminium/pfc/defaults/itemdef.csv
+++ b/business/processes/production/aluminium/pfc/defaults/itemdef.csv
@@ -1,5 +1,3 @@
-name,Aluminium Production: PFC Default Method
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of cell technology,cellType,TEXT,true,true,,,,
 Quantity of aluminium produced,alQuantity,DECIMAL,false,false,kg,,,

--- a/business/processes/production/aluminium/pfc/overvoltage/itemdef.csv
+++ b/business/processes/production/aluminium/pfc/overvoltage/itemdef.csv
@@ -1,5 +1,3 @@
-name,Aluminium Production: PFC Overvoltage Method
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of cell technology,cellType,TEXT,true,true,,,,
 Quantity of aluminium produced,alQuantity,DECIMAL,false,false,kg,,,

--- a/business/processes/production/aluminium/pfc/slope/itemdef.csv
+++ b/business/processes/production/aluminium/pfc/slope/itemdef.csv
@@ -1,5 +1,3 @@
-name,Aluminium Production: PFC Slope Method
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of cell technology,cellType,TEXT,true,true,,,,
 Quantity of aluminium produced,alQuantity,DECIMAL,false,false,kg,,,

--- a/business/processes/production/aluminium/prebake/electrolysis/itemdef.csv
+++ b/business/processes/production/aluminium/prebake/electrolysis/itemdef.csv
@@ -1,5 +1,3 @@
-name,Aluminium Production: Prebake Process - Electrolysis Cells
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Quantity of aluminium produced,aluminiumQuantity,DECIMAL,false,false,kg,,,
 Baked anode consumption per unit production,anodeQuantity,DECIMAL,false,false,kg,kg,,

--- a/business/processes/production/aluminium/prebake/pitchCooking/itemdef.csv
+++ b/business/processes/production/aluminium/prebake/pitchCooking/itemdef.csv
@@ -1,5 +1,3 @@
-name,Aluminium Production: Prebake Process - Pitch Cooking
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Average process weight of green anodes,greenWeight,DECIMAL,false,false,kg,,,
 Average process weight of baked anodes,bakedWeight,DECIMAL,false,false,kg,,,

--- a/business/processes/production/aluminium/sodaAsh/itemdef.csv
+++ b/business/processes/production/aluminium/sodaAsh/itemdef.csv
@@ -1,5 +1,3 @@
-name,Aluminium Production: Soda Ash
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Quantity of Soda Ash,sodaQuantity,DECIMAL,false,false,kg,,,
 Fraction Purity of Soda Ash,sodaFrac,DECIMAL,false,false,,,0.95,

--- a/business/processes/production/aluminium/soderberg/itemdef.csv
+++ b/business/processes/production/aluminium/soderberg/itemdef.csv
@@ -1,5 +1,3 @@
-name,Aluminium Production: Soderberg Process
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of Soderberg potline,soderbergType,TEXT,true,true,,,,
 Type of paste,pasteType,TEXT,true,true,,,,

--- a/business/processes/production/ammonia/itemdef.csv
+++ b/business/processes/production/ammonia/itemdef.csv
@@ -1,5 +1,3 @@
-name,Ammonia
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Plant type,plant,TEXT,true,true,,,,
 Production process,prodProcess,TEXT,true,true,,,,

--- a/business/processes/production/carbide/itemdef.csv
+++ b/business/processes/production/carbide/itemdef.csv
@@ -1,5 +1,3 @@
-name,Carbide production
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of carbide,type,TEXT,true,true,,,,
 Basis for calculation,basis,TEXT,true,true,,,,

--- a/business/processes/production/cement/csi/itemdef.csv
+++ b/business/processes/production/cement/csi/itemdef.csv
@@ -1,5 +1,3 @@
-name,Cement: Raw Materials
-algfile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Clinker Production,clinkerQuantity,DECIMAL,false,false,kg,year,,
 Calcination Emission Factor (corrected for CaO and MgO imports),EF,DECIMAL,false,false,kg,t,0.525,

--- a/business/processes/production/cement/epa/itemdef.csv
+++ b/business/processes/production/cement/epa/itemdef.csv
@@ -1,5 +1,3 @@
-name,Cement Production - Cement-Based Method
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Cement Production,cementQuantity,DECIMAL,false,false,kg,year,,

--- a/business/processes/production/cement/ipcc/carbonate/itemdef.csv
+++ b/business/processes/production/cement/ipcc/carbonate/itemdef.csv
@@ -1,5 +1,3 @@
-name,Cement production by carbonate inputs (IPCC)
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Cement type,type,TEXT,true,true,,,,
 Quantity calcite/aragonite consumed,massCalcite,DECIMAL,false,false,t,,,

--- a/business/processes/production/cement/ipcc/cement/itemdef.csv
+++ b/business/processes/production/cement/ipcc/cement/itemdef.csv
@@ -1,5 +1,3 @@
-name,Cement production (IPCC)
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Quantity cement produced,massCement,DECIMAL,false,false,t,,,

--- a/business/processes/production/cement/ipcc/clinker/itemdef.csv
+++ b/business/processes/production/cement/ipcc/clinker/itemdef.csv
@@ -1,5 +1,3 @@
-name,Clinker production (IPCC)
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Quantity clinker produced,massClinker,DECIMAL,false,false,t,,,

--- a/business/processes/production/electronics/etchingandcvdcleaning/emissionscontrol/itemdef.csv
+++ b/business/processes/production/electronics/etchingandcvdcleaning/emissionscontrol/itemdef.csv
@@ -1,5 +1,3 @@
-name,Electronics emissions control
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Gas,gas,TEXT,true,true,,,,
 Emissions control efficiency for destructive technologies,destructionEfficiency,DECIMAL,true,false,,,,

--- a/business/processes/production/electronics/etchingandcvdcleaning/itemdef.csv
+++ b/business/processes/production/electronics/etchingandcvdcleaning/itemdef.csv
@@ -1,5 +1,3 @@
-name,Electronics etching and cvd cleaning
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Industry sector,sector,TEXT,true,true,,,,
 Process,process,TEXT,true,true,,,,

--- a/business/processes/production/electronics/etchingandcvdcleaning/production/itemdef.csv
+++ b/business/processes/production/electronics/etchingandcvdcleaning/production/itemdef.csv
@@ -1,5 +1,3 @@
-name,Electronics etching and cvd cleaning by production
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Industry sector,sector,TEXT,true,true,,,,
 CF4 emissions per area substrate produced,massCF4PerArea,DECIMAL,true,false,kg,m^2,,

--- a/business/processes/production/electronics/heattransferfluids/consumption/itemdef.csv
+++ b/business/processes/production/electronics/heattransferfluids/consumption/itemdef.csv
@@ -1,5 +1,3 @@
-name,Heat transfer fluids by consumption
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Type of fluid,fluid,TEXT,false,false,,,,

--- a/business/processes/production/electronics/heattransferfluids/production/itemdef.csv
+++ b/business/processes/production/electronics/heattransferfluids/production/itemdef.csv
@@ -1,5 +1,3 @@
-name,Heat transfer fluids by production
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 C6F14 emissions per area substrate produced,massC6F14PerArea,DECIMAL,true,false,kg,m^2,,

--- a/business/processes/production/ferroalloy/ch4/itemdef.csv
+++ b/business/processes/production/ferroalloy/ch4/itemdef.csv
@@ -1,5 +1,3 @@
-name,Ferroalloy methane emissions
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of Alloy,typeOfAlloy,TEXT,true,true,,,,
 Operation of Furnace,operationOfFurnace,TEXT,true,true,,,,

--- a/business/processes/production/ferroalloy/production/itemdef.csv
+++ b/business/processes/production/ferroalloy/production/itemdef.csv
@@ -1,5 +1,3 @@
-name,Ferroalloy production generic methodology
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of Ferroalloy,typeOfFerroalloy,TEXT,true,true,,,,
 Mass CO2 Produced Per Mass Product,massCO2PerMassProduct,DECIMAL,both,false,t,t,,

--- a/business/processes/production/ferroalloy/rawmaterials/itemdef.csv
+++ b/business/processes/production/ferroalloy/rawmaterials/itemdef.csv
@@ -1,5 +1,3 @@
-name,Ferroalloy production raw materials methodology
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of Reducing Agent,typeOfReducingAgent,TEXT,true,true,,,,
 Mass CO2 Produced Per Mass Reducing Agent,massCO2PerMassReducingAgent,DECIMAL,both,false,t,t,,

--- a/business/processes/production/fluorinatedcompounds/production/itemdef.csv
+++ b/business/processes/production/fluorinatedcompounds/production/itemdef.csv
@@ -1,5 +1,3 @@
-name,Fluorinated compound production
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of fluorinated compound produced,type,TEXT,true,true,,,,
 Quantity of emissions per quantity of production,massPerMass,DECIMAL,both,false,t,t,,

--- a/business/processes/production/glass/carbonate/itemdef.csv
+++ b/business/processes/production/glass/carbonate/itemdef.csv
@@ -1,5 +1,3 @@
-name,Glass production by carbonate inputs
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Glass type,type,TEXT,true,true,,,,
 Quantity calcite/aragonite consumed,massCalcite,DECIMAL,false,false,t,,,

--- a/business/processes/production/glass/generic/itemdef.csv
+++ b/business/processes/production/glass/generic/itemdef.csv
@@ -1,5 +1,3 @@
-name,Generic glass production
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Glass type,type,TEXT,true,true,,,,
 Glass subtype,subtype,TEXT,true,true,,,,

--- a/business/processes/production/hcfc22/fluorineAndCarbon/itemdef.csv
+++ b/business/processes/production/hcfc22/fluorineAndCarbon/itemdef.csv
@@ -1,5 +1,3 @@
-name,HCFC-22 production; fluorine and carbon balance efficiencies method
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Amount of HCFC-22 Produced,quantityHCFC22,DECIMAL,false,false,kg,,,

--- a/business/processes/production/hcfc22/gasStream/itemdef.csv
+++ b/business/processes/production/hcfc22/gasStream/itemdef.csv
@@ -1,5 +1,3 @@
-name,HCFC-22 production; HCFC-22 Gas Stream Methodology
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 HFC-23 Emissions Flow Rate,emissFlowRate,DECIMAL,false,false,m^3,min,,

--- a/business/processes/production/hcfc22/productionDataOnly/itemdef.csv
+++ b/business/processes/production/hcfc22/productionDataOnly/itemdef.csv
@@ -1,5 +1,3 @@
-name,HCFC-22 production; production data only method
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Amount of HCFC-22 Produced,quantityHCFC22,DECIMAL,false,false,kg,,,

--- a/business/processes/production/hydrogen/consumption/itemdef.csv
+++ b/business/processes/production/hydrogen/consumption/itemdef.csv
@@ -1,5 +1,3 @@
-name,Hydrogen production by feedstock
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of process,type,TEXT,true,true,,,,
 Quantity of feedstock consumed,massFeedstock,DECIMAL,false,false,t,year,,

--- a/business/processes/production/hydrogen/production/itemdef.csv
+++ b/business/processes/production/hydrogen/production/itemdef.csv
@@ -1,5 +1,3 @@
-name,Hydrogen production
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Hydrogen production process,process,TEXT,true,true,,,,
 Quantity of CO2 emitted per quantity of hydrogen,massCO2PerMass,DECIMAL,true,false,g,kg,,

--- a/business/processes/production/ironandsteel/coke/itemdef.csv
+++ b/business/processes/production/ironandsteel/coke/itemdef.csv
@@ -1,5 +1,3 @@
-name,Iron and Steel: Coke Production
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Material,material,TEXT,true,true,,,,
 Amount of Material,materialQuantity,DECIMAL,false,false,kg,,,

--- a/business/processes/production/ironandsteel/dri/itemdef.csv
+++ b/business/processes/production/ironandsteel/dri/itemdef.csv
@@ -1,5 +1,3 @@
-name,Iron and Steel: DRI
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Natural Gas Consumption,gasQuantity,DECIMAL,false,false,kg,,,
 Natural Gas Carbon Content,gasCarbon,DECIMAL,false,false,kg,kg,0.73,

--- a/business/processes/production/ironandsteel/epa/eaf/itemdef.csv
+++ b/business/processes/production/ironandsteel/epa/eaf/itemdef.csv
@@ -1,5 +1,3 @@
-name,EAF steel production EPA
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Quantity of carbonate flux,fluxQuantity,DECIMAL,false,false,t,,,

--- a/business/processes/production/ironandsteel/epa/primary/itemdef.csv
+++ b/business/processes/production/ironandsteel/epa/primary/itemdef.csv
@@ -1,5 +1,3 @@
-name,Primary Iron and steel EPA
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Quantity of carbonate flux,fluxQuantity,DECIMAL,false,false,t,,,

--- a/business/processes/production/ironandsteel/generic/itemdef.csv
+++ b/business/processes/production/ironandsteel/generic/itemdef.csv
@@ -1,5 +1,3 @@
-name,Generic iron and steel processes
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Product,product,TEXT,true,true,,,,
 Process,process,TEXT,true,true,,,,

--- a/business/processes/production/ironandsteel/ironAndSteel/itemdef.csv
+++ b/business/processes/production/ironandsteel/ironAndSteel/itemdef.csv
@@ -1,5 +1,3 @@
-name,Iron and Steel: Iron and Steel
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Material,material,TEXT,true,true,,,,
 Amount of Material,materialQuantity,DECIMAL,false,false,kg,,,

--- a/business/processes/production/ironandsteel/sinter/itemdef.csv
+++ b/business/processes/production/ironandsteel/sinter/itemdef.csv
@@ -1,5 +1,3 @@
-name,Iron and Steel: Sinter
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Material,material,TEXT,true,true,,,,
 Amount of Material,materialQuantity,DECIMAL,false,false,kg,,,

--- a/business/processes/production/lead/itemdef.csv
+++ b/business/processes/production/lead/itemdef.csv
@@ -1,5 +1,3 @@
-name,Lead Production
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Lead Production by Source and Furnace Type,leadProductionBySource,TEXT,true,true,,,,
 Mass CO2 Produced Per Mass Product,massCO2PerMassProduct,DECIMAL,both,false,t,t,,

--- a/business/processes/production/lime/carbonate/itemdef.csv
+++ b/business/processes/production/lime/carbonate/itemdef.csv
@@ -1,5 +1,3 @@
-name,Lime Manufacture - Carbonate Data
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Carbonate Type,carbonateType,TEXT,true,true,,,,
 Quantity of Carbonate,carbonateQuantity,DECIMAL,false,false,kg,,,

--- a/business/processes/production/lime/production/generic/itemdef.csv
+++ b/business/processes/production/lime/production/generic/itemdef.csv
@@ -1,5 +1,3 @@
-name,Generic lime production
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Quantity of Lime produced,limeQuantity,DECIMAL,false,false,t,,,

--- a/business/processes/production/lime/production/iai/itemdef.csv
+++ b/business/processes/production/lime/production/iai/itemdef.csv
@@ -1,5 +1,3 @@
-name,Lime production (IAI)
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Quantity of quick lime produced,massQuickLimePerTime,DECIMAL,false,false,t,year,,

--- a/business/processes/production/lime/production/itemdef.csv
+++ b/business/processes/production/lime/production/itemdef.csv
@@ -1,5 +1,3 @@
-name,Lime Manufacture - Production Data
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Lime Type,limeType,TEXT,true,true,,,,
 Quantity of Lime,limeQuantity,DECIMAL,false,false,kg,,,

--- a/business/processes/production/magnesium/castingprocess/itemdef.csv
+++ b/business/processes/production/magnesium/castingprocess/itemdef.csv
@@ -1,5 +1,3 @@
-name,Magnesium Casting
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Magnesium Casting Process,magnesiumCastingProcess,TEXT,true,true,,,,
 Mass SF6 Produced Per Mass Product,massSF6PerMassProduct,DECIMAL,both,false,kg,t,,

--- a/business/processes/production/magnesium/primaryproduction/itemdef.csv
+++ b/business/processes/production/magnesium/primaryproduction/itemdef.csv
@@ -1,5 +1,3 @@
-name,Magnesium Production
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Magnesium Production by Raw Material,magnesiumProductionByRawMaterial,TEXT,true,true,,,,
 Mass CO2 Produced Per Mass Product,massCO2PerMassProduct,DECIMAL,both,false,t,t,,

--- a/business/processes/production/nitricAcid/itemdef.csv
+++ b/business/processes/production/nitricAcid/itemdef.csv
@@ -1,5 +1,3 @@
-name,Nitric Acid N2O emissions
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Quantity of Nitric Acid,acidQuantity,DECIMAL,false,false,kg,,,
 Emissions Factor,specEmFact,DECIMAL,false,false,kg,kg,,

--- a/business/processes/production/petrochemical/generic/acrylonitrile/itemdef.csv
+++ b/business/processes/production/petrochemical/generic/acrylonitrile/itemdef.csv
@@ -1,5 +1,3 @@
-name,Acrylonitrile production
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of process,process,TEXT,true,true,,,,
 Quantity of CO2 per unit of acrylonitrile produced,massCO2PerMass,DECIMAL,true,false,t,t,,

--- a/business/processes/production/petrochemical/generic/carbonblack/itemdef.csv
+++ b/business/processes/production/petrochemical/generic/carbonblack/itemdef.csv
@@ -1,5 +1,3 @@
-name,Carbon black production
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of process,process,TEXT,true,true,,,,
 Type of feedstock,feedstock,TEXT,true,true,,,,

--- a/business/processes/production/petrochemical/generic/ethylene/itemdef.csv
+++ b/business/processes/production/petrochemical/generic/ethylene/itemdef.csv
@@ -1,5 +1,3 @@
-name,Ethylene production
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of feedstock,feedstock,TEXT,true,true,,,,
 Type of process,process,TEXT,true,true,,,,

--- a/business/processes/production/petrochemical/generic/ethylenedichloride/itemdef.csv
+++ b/business/processes/production/petrochemical/generic/ethylenedichloride/itemdef.csv
@@ -1,5 +1,3 @@
-name,Ethylene dichloride production
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of process,process,TEXT,true,true,,,,
 Type of emission,emission,TEXT,true,true,,,,

--- a/business/processes/production/petrochemical/generic/ethyleneoxide/itemdef.csv
+++ b/business/processes/production/petrochemical/generic/ethyleneoxide/itemdef.csv
@@ -1,5 +1,3 @@
-name,Ethylene oxide production
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of process,process,TEXT,true,true,,,,
 Catalyst selectivity,catalystSelectivity,DECIMAL,true,true,,,,

--- a/business/processes/production/petrochemical/generic/methanol/itemdef.csv
+++ b/business/processes/production/petrochemical/generic/methanol/itemdef.csv
@@ -1,5 +1,3 @@
-name,Methanol production
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of feedstock,feedstock,TEXT,true,true,,,,
 Type of process,process,TEXT,true,true,,,,

--- a/business/processes/production/petrochemical/generic/vinylchloridemonomer/itemdef.csv
+++ b/business/processes/production/petrochemical/generic/vinylchloridemonomer/itemdef.csv
@@ -1,5 +1,3 @@
-name,Vinyl chloride monomer production
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of process,process,TEXT,true,true,,,,
 Type of emission,emission,TEXT,true,true,,,,

--- a/business/processes/production/petrochemical/massbalance/carboncontent/itemdef.csv
+++ b/business/processes/production/petrochemical/massbalance/carboncontent/itemdef.csv
@@ -1,5 +1,3 @@
-name,Petrochemical carbon contents
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of petrochemical/feedstock,type,TEXT,true,true,,,,
 Carbon content,carbonContent,DECIMAL,true,false,t,t,,

--- a/business/processes/production/petrochemical/massbalance/itemdef.csv
+++ b/business/processes/production/petrochemical/massbalance/itemdef.csv
@@ -1,5 +1,3 @@
-name,Petrochemical mass balance methodology
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of petrochemical,product,TEXT,true,true,,,,
 Primary feedstock,primaryFeedstock,TEXT,both,false,,,,

--- a/business/processes/production/phosphoricacid/itemdef.csv
+++ b/business/processes/production/phosphoricacid/itemdef.csv
@@ -1,5 +1,3 @@
-name,Phosphoric acid production
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Region of source phosphate rock,region,TEXT,true,true,,,,
 Total carbon content of phosphate,massTotalCarbonPerMass,DECIMAL,true,false,,,,

--- a/business/processes/production/pulpAndPaper/biomass/itemdef.csv
+++ b/business/processes/production/pulpAndPaper/biomass/itemdef.csv
@@ -1,5 +1,3 @@
-name,Pulp and Paper biomass
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of Boiler,typeOfBoiler,TEXT,true,true,,,,
 Description of Boiler,description,TEXT,true,true,,,,

--- a/business/processes/production/pulpAndPaper/directEmissions/itemdef.csv
+++ b/business/processes/production/pulpAndPaper/directEmissions/itemdef.csv
@@ -1,5 +1,3 @@
-name,Direct emissions from make up chemicals
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Chemical,chemical,TEXT,true,true,,,,

--- a/business/processes/production/pulpAndPaper/pulpingliquor/itemdef.csv
+++ b/business/processes/production/pulpAndPaper/pulpingliquor/itemdef.csv
@@ -1,5 +1,3 @@
-name,Pulp and paper pulping liquor emissions
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of Pulping Liquor,type,TEXT,true,true,,,,
 Wood Furnish,woodFurnish,TEXT,true,true,,,,

--- a/business/processes/production/sodaash/itemdef.csv
+++ b/business/processes/production/sodaash/itemdef.csv
@@ -1,5 +1,3 @@
-name,Soda ash Production
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of calculation,type,TEXT,true,true,,,,
 Mass CO2 Produced Per Mass feedstock/product,massCO2PerMass,DECIMAL,both,false,t,t,,

--- a/business/processes/production/titaniumdioxide/consumption/itemdef.csv
+++ b/business/processes/production/titaniumdioxide/consumption/itemdef.csv
@@ -1,5 +1,3 @@
-name,Titanium dioxide production by feedstock
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of process,type,TEXT,true,true,,,,
 Quantity of feedstock consumed,massFeedstock,DECIMAL,false,false,t,year,,

--- a/business/processes/production/titaniumdioxide/production/itemdef.csv
+++ b/business/processes/production/titaniumdioxide/production/itemdef.csv
@@ -1,5 +1,3 @@
-name,Titanium dioxide production
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of titanium dioxide product,product,TEXT,true,true,,,,
 Quantity of CO2 emitted per quantity of product,massCO2PerMass,DECIMAL,both,false,t,t,,

--- a/business/processes/production/zinc/itemdef.csv
+++ b/business/processes/production/zinc/itemdef.csv
@@ -1,5 +1,3 @@
-name,Zinc Production
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Zinc Production by Source and Furnace Type,zincProductionBySource,TEXT,true,true,,,,
 Mass CO2 Produced Per Mass Product,massCO2PerMassProduct,DECIMAL,both,false,t,t,,

--- a/business/processes/refrigeration/disposal/itemdef.csv
+++ b/business/processes/refrigeration/disposal/itemdef.csv
@@ -1,5 +1,3 @@
-name,Refrigeration Disposal
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of Equipment,type,TEXT,true,true,,,,
 Percentage Capacity Remaining at Disposal,capacityRemainingAtDisposal,DECIMAL,true,false,,,,

--- a/business/processes/refrigeration/installation/itemdef.csv
+++ b/business/processes/refrigeration/installation/itemdef.csv
@@ -1,5 +1,3 @@
-name,Refrigeration Installation
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of Equipment,type,TEXT,true,true,,,,
 Installation Percentage Emission Factor,installationEmissionFactor,DECIMAL,true,false,,,,

--- a/business/processes/refrigeration/materialbalance/itemdef.csv
+++ b/business/processes/refrigeration/materialbalance/itemdef.csv
@@ -1,5 +1,3 @@
-name,Refrigerant Material Balance by DEFRA
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Type of refrigerant,refrigerant,TEXT,false,false,,,,

--- a/business/processes/refrigeration/operation/itemdef.csv
+++ b/business/processes/refrigeration/operation/itemdef.csv
@@ -1,5 +1,3 @@
-name,Refrigeration Operation
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of Equipment,type,TEXT,true,true,,,,
 Annual Percentage Leak Rate,annualLeakRate,DECIMAL,true,false,,year,,

--- a/business/supplychain/itemdef.csv
+++ b/business/supplychain/itemdef.csv
@@ -1,5 +1,3 @@
-name,Supply Chain Indirect Emissions
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Product Category,productCategory,TEXT,true,true,,,,
 SIC code (SIC 2003),sicCode,TEXT,true,false,,,,

--- a/business/waste/bio/itemdef.csv
+++ b/business/waste/bio/itemdef.csv
@@ -1,5 +1,3 @@
-name,Biological waste treatment
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Treatment type,type,TEXT,true,true,,,,
 CH4 emissions factor (dry weight basis),massCH4PerDryMass,DECIMAL,true,false,g,kg,,

--- a/business/waste/combustion/industrial/itemdef.csv
+++ b/business/waste/combustion/industrial/itemdef.csv
@@ -1,5 +1,3 @@
-name,Industrial waste combustion
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Industry sector,industry,TEXT,true,true,,,,
 Waste water content,waterContent,DECIMAL,true,false,,,,

--- a/business/waste/combustion/municipal/itemdef.csv
+++ b/business/waste/combustion/municipal/itemdef.csv
@@ -1,5 +1,3 @@
-name,Municipal waste combustion
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of waste,type,TEXT,true,true,,,,
 Method of burning,method,TEXT,true,true,,,,

--- a/business/waste/combustion/other/itemdef.csv
+++ b/business/waste/combustion/other/itemdef.csv
@@ -1,5 +1,3 @@
-name,Other generic waste combustion
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Waste type,type,TEXT,true,true,,,,
 Total carbon content,totalCarbonContent,DECIMAL,true,false,,,,

--- a/business/waste/recovery/itemdef.csv
+++ b/business/waste/recovery/itemdef.csv
@@ -1,5 +1,3 @@
-name,wasteRecovery
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Collected,collected,DECIMAL,false,false,m^3,year,,
 Collection Efficiency,collectionEfficiency,DECIMAL,false,false,,,0.75,

--- a/business/waste/steadyState/itemdef.csv
+++ b/business/waste/steadyState/itemdef.csv
@@ -1,5 +1,3 @@
-name,wasteSteadyState
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Waste Deposition Rate,wasteDepositionRate,DECIMAL,false,false,t,year,,
 Time since closed,timeSinceClosed,DECIMAL,false,false,year,,,

--- a/business/waste/water/anaerobicdigester/itemdef.csv
+++ b/business/waste/water/anaerobicdigester/itemdef.csv
@@ -1,5 +1,3 @@
-name,Water treatment anaerobic digestion
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of process,type,TEXT,true,true,,,,
 Total volumetric flow,volumetricFlow,DECIMAL,false,false,ft^3,min,,

--- a/business/waste/water/domestic/itemdef.csv
+++ b/business/waste/water/domestic/itemdef.csv
@@ -1,5 +1,3 @@
-name,Domestic water treatment
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Water treatment type,type,TEXT,true,true,,,,
 Discharge pathway,system,TEXT,true,true,,,,

--- a/business/waste/water/industrial/industryfactors/itemdef.csv
+++ b/business/waste/water/industrial/industryfactors/itemdef.csv
@@ -1,5 +1,3 @@
-name,Industry typical waste water
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Industry,industry,TEXT,true,true,,,,
 Typical waste water per production,volumeWasteWaterPerMassProduction,DECIMAL,true,false,m^3,t,,

--- a/business/waste/water/industrial/itemdef.csv
+++ b/business/waste/water/industrial/itemdef.csv
@@ -1,5 +1,3 @@
-name,Industrial waste water
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Water treatment type,type,TEXT,true,true,,,,
 Discharge pathway,system,TEXT,true,true,,,,

--- a/business/waste/water/n2o/itemdef.csv
+++ b/business/waste/water/n2o/itemdef.csv
@@ -1,5 +1,3 @@
-name,Water treatment N2O
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of process,type,TEXT,true,true,,,,
 Total service population,totalPopulation,DECIMAL,false,false,,,,

--- a/embodied/ice/concrete/itemdef.csv
+++ b/embodied/ice/concrete/itemdef.csv
@@ -1,5 +1,3 @@
-name,Concrete
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Subtype,subtype,TEXT,true,true,,,,

--- a/embodied/ice/itemdef.csv
+++ b/embodied/ice/itemdef.csv
@@ -1,5 +1,3 @@
-name,Inventory of carbon and energy (ICE)
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Material,material,TEXT,true,true,,,,
 Type,type,TEXT,true,true,,,,

--- a/embodied/ice/v2/area/itemdef.csv
+++ b/embodied/ice/v2/area/itemdef.csv
@@ -1,5 +1,3 @@
-name,ICE v2 by area
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Material,material,TEXT,true,true,,,,
 Material type,type,TEXT,true,true,,,,

--- a/embodied/ice/v2/concrete/itemdef.csv
+++ b/embodied/ice/v2/concrete/itemdef.csv
@@ -1,5 +1,3 @@
-name,ICE v2 concrete
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Concrete type,type,TEXT,true,true,,,,
 Concrete subtype,subtype,TEXT,true,true,,,,

--- a/embodied/ice/v2/mass/itemdef.csv
+++ b/embodied/ice/v2/mass/itemdef.csv
@@ -1,5 +1,3 @@
-name,ICE v2 by mass
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Material,material,TEXT,true,true,,,,
 Material type,type,TEXT,true,true,,,,

--- a/embodied/ice/v2/references/itemdef.csv
+++ b/embodied/ice/v2/references/itemdef.csv
@@ -1,5 +1,3 @@
-name,ICE v2 references
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Reference number,reference,TEXT,true,true,,,,
 Reference title,title,TEXT,true,false,,,,

--- a/embodied/ice/v2/timber/itemdef.csv
+++ b/embodied/ice/v2/timber/itemdef.csv
@@ -1,5 +1,3 @@
-name,ICE v2 timber
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Timber type,type,TEXT,true,true,,,,
 Embodied energy per unit timber,energyPerMass,DECIMAL,true,false,MJ,kg,,

--- a/embodied/ice/v2/window/fill/itemdef.csv
+++ b/embodied/ice/v2/window/fill/itemdef.csv
@@ -1,5 +1,3 @@
-name,ICE v2 window fills
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fill type,type,TEXT,true,true,,,,
 Embodied energy per window,energyPerWindow,DECIMAL,true,false,MJ,,,

--- a/embodied/ice/v2/window/itemdef.csv
+++ b/embodied/ice/v2/window/itemdef.csv
@@ -1,5 +1,3 @@
-name,ICE v2 window
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Frame type,type,TEXT,true,true,,,,
 Glazing type,glazing,TEXT,true,true,,,,

--- a/home/appliances/computers/generic/itemdef.csv
+++ b/home/appliances/computers/generic/itemdef.csv
@@ -1,5 +1,3 @@
-name,Computers Generic
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Device,device,TEXT,true,true,,,,
 Rating,rating,TEXT,true,true,,,,

--- a/home/appliances/cooking/hob/itemdef.csv
+++ b/home/appliances/cooking/hob/itemdef.csv
@@ -1,5 +1,3 @@
-name,Hob
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Base kWh per year,baseKWhPerYear,DECIMAL,true,false,,,,

--- a/home/appliances/cooking/itemdef.csv
+++ b/home/appliances/cooking/itemdef.csv
@@ -1,5 +1,3 @@
-name,Cooking
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Number Of People,numberOfPeople,DECIMAL,true,true,,,,
 Fuel,fuel,TEXT,true,true,,,,

--- a/home/appliances/cooking/oven/itemdef.csv
+++ b/home/appliances/cooking/oven/itemdef.csv
@@ -1,5 +1,3 @@
-name,Oven
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Base kWh per year,baseKWhPerYear,DECIMAL,true,false,,,,

--- a/home/appliances/cooking/us/itemdef.csv
+++ b/home/appliances/cooking/us/itemdef.csv
@@ -1,5 +1,3 @@
-name,Cooktop US
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Cooker Type,cookerType,TEXT,true,true,,,,
 Fuel Type,fuelType,TEXT,true,true,,,,

--- a/home/appliances/energystar/entertainment/setTopBoxes/itemdef.csv
+++ b/home/appliances/energystar/entertainment/setTopBoxes/itemdef.csv
@@ -1,5 +1,3 @@
-name,Energy Star Set Top Boxes
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Company Name,companyName,TEXT,true,true,,,,
 Brand Name,brandName,TEXT,true,true,,,,

--- a/home/appliances/energystar/entertainment/televisionsAndCombinationUnits/itemdef.csv
+++ b/home/appliances/energystar/entertainment/televisionsAndCombinationUnits/itemdef.csv
@@ -1,5 +1,3 @@
-name,Energy Star Televisions
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Company Name,companyName,TEXT,true,true,,,,
 Brand Name,brandName,TEXT,true,true,,,,

--- a/home/appliances/energystar/kitchen/clothesWashers/itemdef.csv
+++ b/home/appliances/energystar/kitchen/clothesWashers/itemdef.csv
@@ -1,5 +1,3 @@
-name,Energy Star Clothes Washers
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Brand,brand,TEXT,true,true,,,,
 Model,model,TEXT,true,true,,,,

--- a/home/appliances/energystar/kitchen/dishwashers/itemdef.csv
+++ b/home/appliances/energystar/kitchen/dishwashers/itemdef.csv
@@ -1,5 +1,3 @@
-name,Energy Star Dishwashers
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Brand,brand,TEXT,true,true,,,,
 Model,model,TEXT,true,true,,,,

--- a/home/appliances/energystar/kitchen/freezers/itemdef.csv
+++ b/home/appliances/energystar/kitchen/freezers/itemdef.csv
@@ -1,5 +1,3 @@
-name,Energy Star Freezers
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Brand,brand,TEXT,true,true,,,,
 Model,model,TEXT,true,true,,,,

--- a/home/appliances/energystar/kitchen/refrigerators/itemdef.csv
+++ b/home/appliances/energystar/kitchen/refrigerators/itemdef.csv
@@ -1,5 +1,3 @@
-name,Energy Star Refrigerators
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Brand,brand,TEXT,true,true,,,,
 Model,model,TEXT,true,true,,,,

--- a/home/appliances/energystar/office/computers/desktopsAndIntegrated/itemdef.csv
+++ b/home/appliances/energystar/office/computers/desktopsAndIntegrated/itemdef.csv
@@ -1,5 +1,3 @@
-name,Energy Star Computers
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Product Type,productType,TEXT,true,true,,,,
 Brand,brand,TEXT,true,true,,,,

--- a/home/appliances/energystar/office/computers/notebooksAndTablets/itemdef.csv
+++ b/home/appliances/energystar/office/computers/notebooksAndTablets/itemdef.csv
@@ -1,5 +1,3 @@
-name,Energy Star Laptops
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Product Type,productType,TEXT,true,true,,,,
 Brand,brand,TEXT,true,true,,,,

--- a/home/appliances/energystar/office/computers/workstations/itemdef.csv
+++ b/home/appliances/energystar/office/computers/workstations/itemdef.csv
@@ -1,5 +1,3 @@
-name,Energy Star Workstations
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Product Type,productType,TEXT,true,true,,,,
 Brand,brand,TEXT,true,true,,,,

--- a/home/appliances/energystar/office/imageEquipment/copiers/itemdef.csv
+++ b/home/appliances/energystar/office/imageEquipment/copiers/itemdef.csv
@@ -1,5 +1,3 @@
-name,Energy Star Copiers
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Brand Name,brandName,TEXT,true,true,,,,
 Model Name,modelName,TEXT,true,true,,,,

--- a/home/appliances/energystar/office/imageEquipment/digitalDuplicators/itemdef.csv
+++ b/home/appliances/energystar/office/imageEquipment/digitalDuplicators/itemdef.csv
@@ -1,5 +1,3 @@
-name,Energy Star Digital Duplicators
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Brand Name,brandName,TEXT,true,true,,,,
 Model Name,modelName,TEXT,true,true,,,,

--- a/home/appliances/energystar/office/imageEquipment/faxMachines/itemdef.csv
+++ b/home/appliances/energystar/office/imageEquipment/faxMachines/itemdef.csv
@@ -1,5 +1,3 @@
-name,Energy Star Fax Machines
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Brand Name,brandName,TEXT,true,true,,,,
 Model Name,modelName,TEXT,true,true,,,,

--- a/home/appliances/energystar/office/imageEquipment/multiFunctionDevices/itemdef.csv
+++ b/home/appliances/energystar/office/imageEquipment/multiFunctionDevices/itemdef.csv
@@ -1,5 +1,3 @@
-name,Energy Star Multi-Function Devices
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Brand Name,brandName,TEXT,true,true,,,,
 Model Name,modelName,TEXT,true,true,,,,

--- a/home/appliances/energystar/office/imageEquipment/printers/itemdef.csv
+++ b/home/appliances/energystar/office/imageEquipment/printers/itemdef.csv
@@ -1,5 +1,3 @@
-name,Energy Star Printers
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Brand Name,brandName,TEXT,true,true,,,,
 Model Name,modelName,TEXT,true,true,,,,

--- a/home/appliances/entertainment/generic/itemdef.csv
+++ b/home/appliances/entertainment/generic/itemdef.csv
@@ -1,5 +1,3 @@
-name,Entertainment Generic
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Device,device,TEXT,true,true,,,,
 Rating,rating,TEXT,true,true,,,,

--- a/home/appliances/kitchen/generic/itemdef.csv
+++ b/home/appliances/kitchen/generic/itemdef.csv
@@ -1,5 +1,3 @@
-name,Kitchen Generic
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Device,device,TEXT,true,true,,,,
 Rating,rating,TEXT,true,true,,,,

--- a/home/appliances/televisions/generic/itemdef.csv
+++ b/home/appliances/televisions/generic/itemdef.csv
@@ -1,5 +1,3 @@
-name,Televisions Generic
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Size,size,TEXT,true,true,,,,

--- a/home/appliances/televisions/generic/ranges/itemdef.csv
+++ b/home/appliances/televisions/generic/ranges/itemdef.csv
@@ -1,5 +1,3 @@
-name,Televisions Generic Ranges
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Size,size,TEXT,true,true,in,,,

--- a/home/energy/electricity/itemdef.csv
+++ b/home/energy/electricity/itemdef.csv
@@ -1,5 +1,3 @@
-name,Electricity
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Country,country,TEXT,true,true,,,,
 kgCO2 Per KWh,kgCO2PerKWh,DECIMAL,true,false,,,,

--- a/home/energy/electricity/realTimeElectricity/fuelEmissionFactors/itemdef.csv
+++ b/home/energy/electricity/realTimeElectricity/fuelEmissionFactors/itemdef.csv
@@ -1,5 +1,3 @@
-name,Electricity Generation Emission Factors
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel Type,fuel,TEXT,true,true,,,,
 Mass CO2 Produced per Energy Unit,kgCO2PerKWh,DECIMAL,true,false,kg,kWh,,

--- a/home/energy/electricity/realTimeElectricity/itemdef.csv
+++ b/home/energy/electricity/realTimeElectricity/itemdef.csv
@@ -1,5 +1,3 @@
-name,Real Time Electricity Values
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Country,country,TEXT,true,true,,,,
 Close cycle gas turbine,ccgt,DECIMAL,true,false,kWh,,,

--- a/home/energy/electricity/realTimeIntermediate/itemdef.csv
+++ b/home/energy/electricity/realTimeIntermediate/itemdef.csv
@@ -1,5 +1,3 @@
-name,Real Time Electricity Intermediate
-algFile,default.js,,,,,,,
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Country,country,TEXT,true,true,,,,
 Energy used,energyUsed,DECIMAL,false,false,kWh,year,,

--- a/home/energy/electricityiso/itemdef.csv
+++ b/home/energy/electricityiso/itemdef.csv
@@ -1,5 +1,3 @@
-name,Electricity
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Country,country,TEXT,true,true,,,,
 kgCO2 Per KWh,kgCO2PerKWh,DECIMAL,true,false,,,,

--- a/home/energy/insulation/itemdef.csv
+++ b/home/energy/insulation/itemdef.csv
@@ -1,5 +1,3 @@
-name,Insulation
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Description,description,TEXT,false,false,,,,
 Source,source,TEXT,true,false,,,,

--- a/home/energy/ireland/suppliers/itemdef.csv
+++ b/home/energy/ireland/suppliers/itemdef.csv
@@ -1,5 +1,3 @@
-name,Energy UK Suppliers
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Supplier,supplier,TEXT,true,true,,,,
 Source,source,TEXT,true,false,,,,

--- a/home/energy/quantity/itemdef.csv
+++ b/home/energy/quantity/itemdef.csv
@@ -1,5 +1,3 @@
-name,Energy Quantity
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 kgCO2 Per KWh,kgCO2PerKWh,DECIMAL,true,false,,,,

--- a/home/energy/renewable/itemdef.csv
+++ b/home/energy/renewable/itemdef.csv
@@ -1,5 +1,3 @@
-name,Renewable
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Description,description,TEXT,false,false,,,,
 kWh generated per month,kWhGeneratedPerMonth,DECIMAL,false,false,,,,

--- a/home/energy/uk/price/itemdef.csv
+++ b/home/energy/uk/price/itemdef.csv
@@ -1,5 +1,3 @@
-name,Energy UK Price
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Payment,payment,TEXT,true,true,,,,

--- a/home/energy/uk/reductions/itemdef.csv
+++ b/home/energy/uk/reductions/itemdef.csv
@@ -1,5 +1,3 @@
-name,Reduction
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Action,action,TEXT,true,true,,,,
 kgCO2 Reduction Per Year,kgCO2ReductionPerYear,DECIMAL,true,false,,,,

--- a/home/energy/uk/seasonal/itemdef.csv
+++ b/home/energy/uk/seasonal/itemdef.csv
@@ -1,5 +1,3 @@
-name,Energy UK Seasonal
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Name,name,TEXT,true,true,,,,
 Energy,energy,TEXT,true,true,,,,

--- a/home/energy/uk/seasonal2/itemdef.csv
+++ b/home/energy/uk/seasonal2/itemdef.csv
@@ -1,5 +1,3 @@
-name,Energy UK Seasonal
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Source,source,TEXT,true,false,,,,
 Usage Per Quarter,usagePerQuarter,DECIMAL,false,false,,,0,

--- a/home/energy/uk/suppliers/itemdef.csv
+++ b/home/energy/uk/suppliers/itemdef.csv
@@ -1,5 +1,3 @@
-name,Energy UK Suppliers
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Supplier,supplier,TEXT,true,true,,,,
 kgCO2 Per KWh,kgCO2PerKWh,DECIMAL,true,false,kg,kWh,,

--- a/home/energy/us/price/itemdef.csv
+++ b/home/energy/us/price/itemdef.csv
@@ -1,5 +1,3 @@
-name,Energy US Price
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Source,source,TEXT,true,false,,,,

--- a/home/energy/us/state/itemdef.csv
+++ b/home/energy/us/state/itemdef.csv
@@ -1,5 +1,3 @@
-name,Energy US State
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 kWh Per Month,kWhPerMonth,DECIMAL,false,false,,,,
 State,state,TEXT,true,true,,,,

--- a/home/heating/itemdef.csv
+++ b/home/heating/itemdef.csv
@@ -1,5 +1,3 @@
-name,Heating
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Home Dwelling Type,homeDwellingType,TEXT,true,true,,,,
 Number Of Bedrooms,homeNoOfBedrooms,TEXT,true,true,,,,

--- a/home/heating/uk/floorareas/itemdef.csv
+++ b/home/heating/uk/floorareas/itemdef.csv
@@ -1,5 +1,3 @@
-name,Heating UK Floor Area
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Home type,homeType,TEXT,true,true,,,,
 Number of bedrooms,numberOfBedrooms,TEXT,true,true,,,,

--- a/home/heating/uk/heatingtypes/itemdef.csv
+++ b/home/heating/uk/heatingtypes/itemdef.csv
@@ -1,5 +1,3 @@
-name,Heating UK types
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel,fuel,TEXT,true,true,,,,
 Heating type,heatingType,TEXT,true,true,,,,

--- a/home/heating/uk/itemdef.csv
+++ b/home/heating/uk/itemdef.csv
@@ -1,5 +1,3 @@
-name,Heating UK
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Home type,homeType,TEXT,true,true,,,,
 Fuel,fuel,TEXT,true,true,,,,

--- a/home/heating/uk/renewable/itemdef.csv
+++ b/home/heating/uk/renewable/itemdef.csv
@@ -1,5 +1,3 @@
-name,Heating UK Renewable
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Energy generated,energyGenerated,DECIMAL,true,false,kWh,year,,

--- a/home/heating/us/itemdef.csv
+++ b/home/heating/us/itemdef.csv
@@ -1,5 +1,3 @@
-name,Heating US
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel,fuel,TEXT,true,true,,,,
 is Air Con,isAirCon,TEXT,false,false,,,true,

--- a/home/lighting/generic/itemdef.csv
+++ b/home/lighting/generic/itemdef.csv
@@ -1,5 +1,3 @@
-name,Lighting generic
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Location (country/region),location,TEXT,true,true,,,,
 Type of light bulb,type,TEXT,true,true,,,,

--- a/home/lighting/itemdef.csv
+++ b/home/lighting/itemdef.csv
@@ -1,5 +1,3 @@
-name,Lighting
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,normal,
 kWh Per Year,kWhPerYear,DECIMAL,true,false,,,0,

--- a/home/lighting/specific/itemdef.csv
+++ b/home/lighting/specific/itemdef.csv
@@ -1,5 +1,3 @@
-name,Light bulb by wattage
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Time used per time period,timePerTimePeriod,DECIMAL,false,false,h,day,,

--- a/home/waste/itemdef.csv
+++ b/home/waste/itemdef.csv
@@ -1,5 +1,3 @@
-name,Waste
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 kg per month,kgPerMonth,DECIMAL,false,false,,,,
 Disposal method,savingType,TEXT,false,false,,,,

--- a/home/waste/lifecyclewaste/itemdef.csv
+++ b/home/waste/lifecyclewaste/itemdef.csv
@@ -1,5 +1,3 @@
-name,Waste Disposal Life-Cycle
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Waste Type,wasteType,TEXT,true,true,,,,
 kgCO2e Emitted Per Tonne Recycled Material,kgCO2ePerTonneRecycled,DECIMAL,true,false,kg,t,,

--- a/home/waste/lifecyclewaste2011/itemdef.csv
+++ b/home/waste/lifecyclewaste2011/itemdef.csv
@@ -1,5 +1,3 @@
-name,Waste Disposal Life-Cycle 2011
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Waste type,wasteType,TEXT,true,true,,,,
 Waste sub-type,wasteSubType,TEXT,true,true,,,,

--- a/home/water/defra/itemdef.csv
+++ b/home/water/defra/itemdef.csv
@@ -1,5 +1,3 @@
-name,Water life-cycle
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Quantity CO2 Equivalent Per Quantity Water,kgCO2ePerCubicMetre,DECIMAL,true,false,kg,m^3,,

--- a/home/water/itemdef.csv
+++ b/home/water/itemdef.csv
@@ -1,5 +1,3 @@
-name,Water
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 kgCO2 per litre,kgCO2PerLitre,DECIMAL,true,false,,,,
 kWh per litre,kWhPerLitre,DECIMAL,true,false,,,,

--- a/home/water/reductions/itemdef.csv
+++ b/home/water/reductions/itemdef.csv
@@ -1,5 +1,3 @@
-name,Water Reductions
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 litres per day,litresPerDay,DECIMAL,true,false,,,,
 Source,source,TEXT,true,false,,,,

--- a/home/water/usage/itemdef.csv
+++ b/home/water/usage/itemdef.csv
@@ -1,5 +1,3 @@
-name,Water Usage
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 litres per use,litresPerUse,DECIMAL,true,false,,,,
 litres per minute,litresPerMinute,DECIMAL,true,false,,,,

--- a/metadata/actonco2/actions/itemdef.csv
+++ b/metadata/actonco2/actions/itemdef.csv
@@ -1,5 +1,3 @@
-name,ActOnCO2 Action
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Brief tip content,briefTipContent,TEXT,true,false,,,,

--- a/metadata/actonco2/itemdef.csv
+++ b/metadata/actonco2/itemdef.csv
@@ -1,5 +1,3 @@
-name,ActOnCO2 Metadata
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Home ownership,homeOwnership,TEXT,false,false,,,,

--- a/metadata/hotel/itemdef.csv
+++ b/metadata/hotel/itemdef.csv
@@ -1,5 +1,3 @@
-name,Hotel Metadata
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Source,source,TEXT,true,false,,,N/A,

--- a/metadata/itemdef.csv
+++ b/metadata/itemdef.csv
@@ -1,5 +1,3 @@
-name,Metadata
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Adults in household,adultsInHousehold,INTEGER,false,false,,,,
 Building Type,buildingType,TEXT,false,false,,,,

--- a/personal/generic/itemdef.csv
+++ b/personal/generic/itemdef.csv
@@ -1,5 +1,3 @@
-name,Personal
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 type,type,TEXT,true,true,,,,
 Source,source,TEXT,true,false,,,,

--- a/personal/itemdef.csv
+++ b/personal/itemdef.csv
@@ -1,5 +1,3 @@
-name,Personal
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 type,type,TEXT,true,true,,,,
 Source,source,TEXT,true,false,,,,

--- a/planet/co2Sinks/rainforest/itemdef.csv
+++ b/planet/co2Sinks/rainforest/itemdef.csv
@@ -1,5 +1,3 @@
-name,Carbon Sinks: Rainforest
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Amount of C02,co2Quantity,DECIMAL,false,false,kg,year,,
 Area of rainforest,rainforestArea,DECIMAL,false,false,km^2,,,

--- a/planet/country/aggregate/itemdef.csv
+++ b/planet/country/aggregate/itemdef.csv
@@ -1,5 +1,3 @@
-Name,Country Aggregate
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Source,source,TEXT,true,false,,,,
 Country,country,TEXT,true,true,,,,

--- a/planet/country/uk/aggregate/actonco2/peoplelikeme/appliances/itemdef.csv
+++ b/planet/country/uk/aggregate/actonco2/peoplelikeme/appliances/itemdef.csv
@@ -1,5 +1,3 @@
-name,People Like Me Appliances
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown
 Number of people,numberOfPeople,TEXT,true,true
 CO2,CO2,DECIMAL,true,false

--- a/planet/country/uk/aggregate/actonco2/peoplelikeme/home/itemdef.csv
+++ b/planet/country/uk/aggregate/actonco2/peoplelikeme/home/itemdef.csv
@@ -1,5 +1,3 @@
-name,People Like Me Home
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown
 Age,age,TEXT,true,true
 Number of bedrooms,numberOfBedrooms,TEXT,true,true

--- a/planet/country/uk/aggregate/actonco2/peoplelikeme/travel/itemdef.csv
+++ b/planet/country/uk/aggregate/actonco2/peoplelikeme/travel/itemdef.csv
@@ -1,5 +1,3 @@
-name,People Like Me Travel
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown
 Rural or urban,ruralOrUrban,TEXT,true,true
 Profile type,profileType,TEXT,true,true

--- a/planet/country/uk/average/appliances/itemdef.csv
+++ b/planet/country/uk/average/appliances/itemdef.csv
@@ -1,5 +1,3 @@
-name,UK Average - Appliances
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Household or Individual UK Average,householdOrIndividual,TEXT,true,true,,,,

--- a/planet/country/uk/average/home/itemdef.csv
+++ b/planet/country/uk/average/home/itemdef.csv
@@ -1,5 +1,3 @@
-name,UK Average - Home
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Household or Individual UK Average,householdOrIndividual,TEXT,true,true,,,,

--- a/planet/country/uk/average/travel/itemdef.csv
+++ b/planet/country/uk/average/travel/itemdef.csv
@@ -1,5 +1,3 @@
-name,UK Average - Travel
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Household or Individual UK Average,householdOrIndividual,TEXT,true,true,,,,

--- a/planet/greenhousegases/gwp/itemdef.csv
+++ b/planet/greenhousegases/gwp/itemdef.csv
@@ -1,5 +1,3 @@
-name,Global Warming Potentials
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Gas,gas,TEXT,true,true,,,,
 Name,name,TEXT,true,false,,,,

--- a/planet/oxidationfactors/itemdef.csv
+++ b/planet/oxidationfactors/itemdef.csv
@@ -1,5 +1,3 @@
-name,Correction factors for unoxidized carbon
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,fuel,TEXT,true,true,,,,
 Guidance Document Source,sourceDocumentation,TEXT,true,true,,,,

--- a/planet/stoichiometries/ratios/itemdef.csv
+++ b/planet/stoichiometries/ratios/itemdef.csv
@@ -1,5 +1,3 @@
-name,Stoichiometries - ratios
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Ratio,ratio,DECIMAL,true,false,,,,
 Source,source,TEXT,true,false,,,,

--- a/transport/bus/generic/defra/itemdef.csv
+++ b/transport/bus/generic/defra/itemdef.csv
@@ -1,5 +1,3 @@
-name,Bus Generic DEFRA
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 kgCO2 Per Passenger Km,kgCO2PerKmPassenger,DECIMAL,true,false,,,,

--- a/transport/bus/generic/ghgp/other/biomassfuel/itemdef.csv
+++ b/transport/bus/generic/ghgp/other/biomassfuel/itemdef.csv
@@ -1,5 +1,3 @@
-name,Bus Generic GHGP other regions biomass fuel
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of Fuel,fuelType,TEXT,true,true,,,,
 CO2 per distance,kgCO2PerMile,DECIMAL,true,false,kg,mi,,

--- a/transport/bus/generic/ghgp/other/itemdef.csv
+++ b/transport/bus/generic/ghgp/other/itemdef.csv
@@ -1,5 +1,3 @@
-name,Bus Generic GHGP other regions
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of Fuel,fuelType,TEXT,true,true,,,,
 CO2 per distance,kgCO2PerMile,DECIMAL,true,false,kg,mi,,

--- a/transport/bus/generic/ghgp/us/biomassfuel/itemdef.csv
+++ b/transport/bus/generic/ghgp/us/biomassfuel/itemdef.csv
@@ -1,5 +1,3 @@
-name,Bus Generic GHGP US biomass fuel
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of Fuel,fuelType,TEXT,true,true,,,,
 CO2 per distance,kgCO2PerMile,DECIMAL,true,false,kg,mi,,

--- a/transport/bus/generic/ghgp/us/itemdef.csv
+++ b/transport/bus/generic/ghgp/us/itemdef.csv
@@ -1,5 +1,3 @@
-name,Bus Generic GHGP US
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of Fuel,fuelType,TEXT,true,true,,,,
 CO2 per distance,kgCO2PerMile,DECIMAL,true,false,kg,mi,,

--- a/transport/bus/generic/ghgp/us/perPassenger/itemdef.csv
+++ b/transport/bus/generic/ghgp/us/perPassenger/itemdef.csv
@@ -1,5 +1,3 @@
-name,Bus GHGP per passenger US
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of vehicle,type,TEXT,true,true,,,,
 CO2 per passenger distance,kgCO2PerPassengerMile,DECIMAL,true,false,kg,mi,,

--- a/transport/bus/generic/ipcc/europe/itemdef.csv
+++ b/transport/bus/generic/ipcc/europe/itemdef.csv
@@ -1,5 +1,3 @@
-name,IPCC European Bus 
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,fuel,TEXT,true,true,,,,
 Emissions control technology,technology,TEXT,true,true,,,,

--- a/transport/bus/generic/ipcc/us/alternativefuels/itemdef.csv
+++ b/transport/bus/generic/ipcc/us/alternativefuels/itemdef.csv
@@ -1,5 +1,3 @@
-name,IPCC US Bus alternative fuel
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,fuel,TEXT,true,true,,,,
 Emissions factor type,factorType,TEXT,true,true,,,,

--- a/transport/bus/generic/itemdef.csv
+++ b/transport/bus/generic/itemdef.csv
@@ -1,5 +1,3 @@
-name,Bus Generic
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 kgCO2 Per Passenger Km,kgCO2PerKmPassenger,DECIMAL,true,false,,,,

--- a/transport/bus/generic/occupancy/itemdef.csv
+++ b/transport/bus/generic/occupancy/itemdef.csv
@@ -1,5 +1,3 @@
-name,busByOccupancy
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Accounted passengers,accountedPassengers,DECIMAL,false,false,,,,
 Context,context,TEXT,true,true,,,,

--- a/transport/byDistance/freight/itemdef.csv
+++ b/transport/byDistance/freight/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGFreight
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 CO2 per freight-distance,massCO2perDistanceMassFreight,DECIMAL,true,false,kg,t*km,,
 Distance travelled,distance,DECIMAL,false,false,km,,,

--- a/transport/byDistance/passenger/itemdef.csv
+++ b/transport/byDistance/passenger/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGPassenger
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Distance,distance,DECIMAL,false,false,km,,,
 Mass CO2 per Passenger Distance,massCO2perPassengerDistance,DECIMAL,true,false,kg,km,,

--- a/transport/byFuel/ipcc/offroad/itemdef.csv
+++ b/transport/byFuel/ipcc/offroad/itemdef.csv
@@ -1,5 +1,3 @@
-name,IPCC European off-road fuels
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,fuel,TEXT,true,true,,,,
 Fuel use context,useContext,TEXT,true,true,,,,

--- a/transport/byFuel/ipcc/ship/itemdef.csv
+++ b/transport/byFuel/ipcc/ship/itemdef.csv
@@ -1,5 +1,3 @@
-name,IPCC Water-borne vehicle fuel
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,fuel,TEXT,true,true,,,,
 Fuel use context,useContext,TEXT,true,true,,,,

--- a/transport/byFuel/ipcc/train/itemdef.csv
+++ b/transport/byFuel/ipcc/train/itemdef.csv
@@ -1,5 +1,3 @@
-name,IPCC train fuels
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,fuel,TEXT,true,true,,,,
 Type of engine,engineType,TEXT,true,true,,,,

--- a/transport/byFuel/itemdef.csv
+++ b/transport/byFuel/itemdef.csv
@@ -1,5 +1,3 @@
-name,mobileCombustion,,,,,,,
-algFile,default.js,,,,,,,
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 EF (Energy),EFNRGCO2,DECIMAL,true,false,kg,GJ,,
 Energy used,NRG,DECIMAL,false,false,,,,

--- a/transport/byFuel/other/biomassfuel/itemdef.csv
+++ b/transport/byFuel/other/biomassfuel/itemdef.csv
@@ -1,5 +1,3 @@
-name,Transport By Fuel GHGP other regions biomass fuel
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel Type,fuelType,TEXT,true,true,,,,
 CO2 per fuel,kgCO2PerUsGallon,DECIMAL,true,false,kg,gal,,

--- a/transport/byFuel/other/itemdef.csv
+++ b/transport/byFuel/other/itemdef.csv
@@ -1,5 +1,3 @@
-name,Transport By Fuel GHGP other regions
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel Type,fuelType,TEXT,true,true,,,,
 CO2 per fuel,kgCO2PerUsGallon,DECIMAL,true,false,kg,gal,,

--- a/transport/byFuel/us/biomassfuel/itemdef.csv
+++ b/transport/byFuel/us/biomassfuel/itemdef.csv
@@ -1,5 +1,3 @@
-name,Transport By Fuel GHGP US biomass fuel
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel Type,fuelType,TEXT,true,true,,,,
 CO2 per fuel,kgCO2PerUsGallon,DECIMAL,true,false,kg,gal,,

--- a/transport/byFuel/us/itemdef.csv
+++ b/transport/byFuel/us/itemdef.csv
@@ -1,5 +1,3 @@
-name,Transport By Fuel GHGP US
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel Type,fuelType,TEXT,true,true,,,,
 CO2 or CO2e,CO2eOrCO2,TEXT,true,true,,,,

--- a/transport/car/bands/ireland/itemdef.csv
+++ b/transport/car/bands/ireland/itemdef.csv
@@ -1,5 +1,3 @@
-name,Car Bands
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Band,band,TEXT,true,true,,,,
 Source,source,TEXT,true,false,,,,

--- a/transport/car/generic/defra/bysize/itemdef.csv
+++ b/transport/car/generic/defra/bysize/itemdef.csv
@@ -1,5 +1,3 @@
-name,Car DEFRA By Size
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel,fuel,TEXT,true,true,,,,
 Size,size,TEXT,true,true,,,,

--- a/transport/car/generic/defra/bytype/itemdef.csv
+++ b/transport/car/generic/defra/bytype/itemdef.csv
@@ -1,5 +1,3 @@
-name,Car DEFRA By Type
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel,fuel,TEXT,true,true,,,,
 Type,type,TEXT,true,true,,,,

--- a/transport/car/generic/electric/itemdef.csv
+++ b/transport/car/generic/electric/itemdef.csv
@@ -1,5 +1,3 @@
-name,Car Generic Electric
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Country,country,TEXT,false,false,,,,
 Distance,distance,DECIMAL,false,false,km,year,,

--- a/transport/car/generic/ghgp/other/itemdef.csv
+++ b/transport/car/generic/ghgp/other/itemdef.csv
@@ -1,5 +1,3 @@
-name,Car Generic GHGP other regions
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of Fuel,fuelType,TEXT,true,true,,,,
 CO2 per distance,kgCO2PerMile,DECIMAL,true,false,kg,mi,,

--- a/transport/car/generic/ghgp/us/itemdef.csv
+++ b/transport/car/generic/ghgp/us/itemdef.csv
@@ -1,5 +1,3 @@
-name,Car Generic GHGP US
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of Fuel,fuelType,TEXT,true,true,,,,
 CO2 per distance,kgCO2PerMile,DECIMAL,true,false,kg,mi,,

--- a/transport/car/generic/ipcc/europe/itemdef.csv
+++ b/transport/car/generic/ipcc/europe/itemdef.csv
@@ -1,5 +1,3 @@
-name,IPCC European Car
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,fuel,TEXT,true,true,,,,
 Emissions control technology,technology,TEXT,true,true,,,,

--- a/transport/car/generic/ipcc/us/alternativefuels/itemdef.csv
+++ b/transport/car/generic/ipcc/us/alternativefuels/itemdef.csv
@@ -1,5 +1,3 @@
-name,IPCC US Car alternative fuel
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,fuel,TEXT,true,true,,,,
 Emissions factor type,factorType,TEXT,true,true,,,,

--- a/transport/car/generic/ipcc/us/conventionalfuels/itemdef.csv
+++ b/transport/car/generic/ipcc/us/conventionalfuels/itemdef.csv
@@ -1,5 +1,3 @@
-name,IPCC US Car conventional fuel
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,fuel,TEXT,true,true,,,,
 Emissions control technology,technology,TEXT,true,true,,,,

--- a/transport/car/generic/itemdef.csv
+++ b/transport/car/generic/itemdef.csv
@@ -1,5 +1,3 @@
-name,Car Generic
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel,fuel,TEXT,true,true,,,,
 Size,size,TEXT,true,true,,,,

--- a/transport/car/specific/hydrogen/itemdef.csv
+++ b/transport/car/specific/hydrogen/itemdef.csv
@@ -1,5 +1,3 @@
-name,Car specific hydrogen
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices,
 Manufacturer,manufacturer,TEXT,true,true,,,,,
 Line,line,TEXT,true,true,,,,,

--- a/transport/car/specific/itemdef.csv
+++ b/transport/car/specific/itemdef.csv
@@ -1,5 +1,3 @@
-name,Car Specific
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Manufacturer,manufacturer,TEXT,true,true,,,,
 Model,model,TEXT,true,true,,,,

--- a/transport/car/specific/us/itemdef.csv
+++ b/transport/car/specific/us/itemdef.csv
@@ -1,5 +1,3 @@
-name,Car Specific US
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Manufacturer,manufacturer,TEXT,true,true,,,,
 Line,line,TEXT,true,true,,,,

--- a/transport/car/specific/us2/itemdef.csv
+++ b/transport/car/specific/us2/itemdef.csv
@@ -1,5 +1,3 @@
-name,Car Specific US2
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Year,year,INTEGER,true,true,,,,
 Manufacturer,manufacturer,TEXT,true,true,,,,

--- a/transport/defra/freight/itemdef.csv
+++ b/transport/defra/freight/itemdef.csv
@@ -1,5 +1,3 @@
-name,DEFRA freight
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of transport,type,TEXT,true,true,,,,
 Subtype of transport,subtype,TEXT,true,true,,,,

--- a/transport/defra/fuel/itemdef.csv
+++ b/transport/defra/fuel/itemdef.csv
@@ -1,5 +1,3 @@
-name,DEFRA transport fuels
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of fuel,fuel,TEXT,true,true,,,,
 Direct CO2 emissions factor,massCO2PerVolume,DECIMAL,true,false,kg,L,,

--- a/transport/defra/passenger/flight/itemdef.csv
+++ b/transport/defra/passenger/flight/itemdef.csv
@@ -1,5 +1,3 @@
-name,DEFRA typical flight distances
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of flight,type,TEXT,true,true,,,,
 Passenger class,passengerClass,TEXT,true,true,,,,

--- a/transport/defra/passenger/itemdef.csv
+++ b/transport/defra/passenger/itemdef.csv
@@ -1,5 +1,3 @@
-name,DEFRA passenger transport
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of transport,type,TEXT,true,true,,,,
 Subtype of transport,subtype,TEXT,true,true,,,,

--- a/transport/defra/route/itemdef.csv
+++ b/transport/defra/route/itemdef.csv
@@ -1,5 +1,3 @@
-name,DEFRA Great Circle Route
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of route,type,TEXT,true,true,,,,
 IATA code 1,IATACode1,TEXT,false,false,,,,

--- a/transport/defra/vehicle/class/itemdef.csv
+++ b/transport/defra/vehicle/class/itemdef.csv
@@ -1,5 +1,3 @@
-name,DEFRA road vehicles by class
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of vehicle,type,TEXT,true,true,,,,
 Type of fuel used,fuel,TEXT,true,true,,,,

--- a/transport/defra/vehicle/hgv/itemdef.csv
+++ b/transport/defra/vehicle/hgv/itemdef.csv
@@ -1,5 +1,3 @@
-name,DEFRA heavy goods vehicles
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of vehicle,type,TEXT,true,true,,,,
 Vehicle size,size,TEXT,true,true,,,,

--- a/transport/defra/vehicle/itemdef.csv
+++ b/transport/defra/vehicle/itemdef.csv
@@ -1,5 +1,3 @@
-name,DEFRA road vehicles by size
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of vehicle,type,TEXT,true,true,,,,
 Type of fuel used,fuel,TEXT,true,true,,,,

--- a/transport/emissionscontrol/ureabasedadditives/itemdef.csv
+++ b/transport/emissionscontrol/ureabasedadditives/itemdef.csv
@@ -1,5 +1,3 @@
-name,Urea-based catalysts
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Mass of urea-based additive,mass,DECIMAL,false,false,kg,,,
 Purity of additive,purity,DECIMAL,false,false,,,,

--- a/transport/ghgp/freight/itemdef.csv
+++ b/transport/ghgp/freight/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGP freight transport
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Freighting type,type,TEXT,true,true,,,,
 Freighting subtype,subtype,TEXT,true,true,,,,

--- a/transport/ghgp/fuel/context/itemdef.csv
+++ b/transport/ghgp/fuel/context/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGP transport fuel by context
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,fuel,TEXT,true,true,,,,
 Context of fuel use,useContext,TEXT,true,true,,,,

--- a/transport/ghgp/fuel/itemdef.csv
+++ b/transport/ghgp/fuel/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGP transport fuels
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,fuel,TEXT,true,true,,,,
 Region,region,TEXT,true,true,,,,

--- a/transport/ghgp/passenger/itemdef.csv
+++ b/transport/ghgp/passenger/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGP passenger transport
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Vehicle type,type,TEXT,true,true,,,,
 Vehicle subtype,subtype,TEXT,true,true,,,,

--- a/transport/ghgp/vehicle/other/itemdef.csv
+++ b/transport/ghgp/vehicle/other/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGP Other regional road vehicles
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Vehicle type,type,TEXT,true,true,,,,
 Fuel type,fuel,TEXT,true,true,,,,

--- a/transport/ghgp/vehicle/uk/heavygoods/itemdef.csv
+++ b/transport/ghgp/vehicle/uk/heavygoods/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGP UK heavy goods vehicles
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Vehicle type,type,TEXT,true,true,,,,
 Vehicle size,size,TEXT,true,true,,,,

--- a/transport/ghgp/vehicle/uk/itemdef.csv
+++ b/transport/ghgp/vehicle/uk/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGP UK road vehicles
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Vehicle type,type,TEXT,true,true,,,,
 Fuel type,fuel,TEXT,true,true,,,,

--- a/transport/ghgp/vehicle/us/itemdef.csv
+++ b/transport/ghgp/vehicle/us/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGP US road vehicles
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Vehicle type,type,TEXT,true,true,,,,
 Fuel type,fuel,TEXT,true,true,,,,

--- a/transport/ipcc/europe/itemdef.csv
+++ b/transport/ipcc/europe/itemdef.csv
@@ -1,5 +1,3 @@
-name,IPCC European transport
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Vehicle type,type,TEXT,true,true,,,,
 Fuel type,fuel,TEXT,true,true,,,,

--- a/transport/ipcc/fuel/itemdef.csv
+++ b/transport/ipcc/fuel/itemdef.csv
@@ -1,5 +1,3 @@
-name,IPCC transport fuels
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of fuel,fuel,TEXT,true,true,,,,
 CO2 emissions per fuel quantity,massCO2PerEnergy,DECIMAL,true,false,kg,TJ,,

--- a/transport/ipcc/us/alternativefuels/itemdef.csv
+++ b/transport/ipcc/us/alternativefuels/itemdef.csv
@@ -1,5 +1,3 @@
-name,IPCC US alternatively fuelled transport
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Vehicle type,type,TEXT,true,true,,,,
 Fuel type,fuel,TEXT,true,true,,,,

--- a/transport/ipcc/us/itemdef.csv
+++ b/transport/ipcc/us/itemdef.csv
@@ -1,5 +1,3 @@
-name,IPCC US conventionally fuelled transport
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Vehicle type,type,TEXT,true,true,,,,
 Fuel type,fuel,TEXT,true,true,,,,

--- a/transport/lgv/generic/defra/itemdef.csv
+++ b/transport/lgv/generic/defra/itemdef.csv
@@ -1,5 +1,3 @@
-name,Heavy Goods DEFRA
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Size,size,TEXT,true,true,,,,

--- a/transport/lgv/generic/freight/defra/itemdef.csv
+++ b/transport/lgv/generic/freight/defra/itemdef.csv
@@ -1,5 +1,3 @@
-name,Heavy Goods Freight DEFRA
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Size,size,TEXT,true,true,,,,

--- a/transport/lgv/generic/freight/ghgp/other/itemdef.csv
+++ b/transport/lgv/generic/freight/ghgp/other/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGP other regional freight
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of vehicle,vehicleType,TEXT,true,true,,,,
 CO2 per weight distance,kgCO2PerTonneKm,DECIMAL,true,false,,,,

--- a/transport/lgv/generic/freight/ghgp/us/heavyduty/itemdef.csv
+++ b/transport/lgv/generic/freight/ghgp/us/heavyduty/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGP heavyduty freight US
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of vehicle,vehicleType,TEXT,true,true,,,,
 Vehicle size,size,TEXT,true,true,,,,

--- a/transport/lgv/generic/freight/ghgp/us/lightgoods/itemdef.csv
+++ b/transport/lgv/generic/freight/ghgp/us/lightgoods/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGP lightgoods freight US
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,fuelType,TEXT,true,true,,,,
 CO2 per weight distance,kgCO2PerTonneKm,DECIMAL,true,false,,,,

--- a/transport/lgv/generic/ghgp/heavyduty/other/biomassfuel/itemdef.csv
+++ b/transport/lgv/generic/ghgp/heavyduty/other/biomassfuel/itemdef.csv
@@ -1,5 +1,3 @@
-name,HDV Generic GHGP other regions biomass fuel
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of HDV,vehicleType,TEXT,true,true,,,,
 Type of Fuel,fuelType,TEXT,true,true,,,,

--- a/transport/lgv/generic/ghgp/heavyduty/other/itemdef.csv
+++ b/transport/lgv/generic/ghgp/heavyduty/other/itemdef.csv
@@ -1,5 +1,3 @@
-name,HDV Generic GHGP other regions
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of HDV,vehicleType,TEXT,true,true,,,,
 Type of Fuel,fuelType,TEXT,true,true,,,,

--- a/transport/lgv/generic/ghgp/heavyduty/us/biomassfuel/itemdef.csv
+++ b/transport/lgv/generic/ghgp/heavyduty/us/biomassfuel/itemdef.csv
@@ -1,5 +1,3 @@
-name,HDV Generic GHGP US biomass fuel
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of HDV,vehicleType,TEXT,true,true,,,,
 Type of Fuel,fuelType,TEXT,true,true,,,,

--- a/transport/lgv/generic/ghgp/heavyduty/us/itemdef.csv
+++ b/transport/lgv/generic/ghgp/heavyduty/us/itemdef.csv
@@ -1,5 +1,3 @@
-name,HDV Generic GHGP US
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of HDV,vehicleType,TEXT,true,true,,,,
 Type of Fuel,fuelType,TEXT,true,true,,,,

--- a/transport/lgv/generic/ghgp/lightgoods/other/biomassfuel/itemdef.csv
+++ b/transport/lgv/generic/ghgp/lightgoods/other/biomassfuel/itemdef.csv
@@ -1,5 +1,3 @@
-name,LGV Generic GHGP other regions biomass fuel
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of Fuel,fuelType,TEXT,true,true,,,,
 CO2 per distance,kgCO2PerMile,DECIMAL,true,false,kg,mi,,

--- a/transport/lgv/generic/ghgp/lightgoods/other/itemdef.csv
+++ b/transport/lgv/generic/ghgp/lightgoods/other/itemdef.csv
@@ -1,5 +1,3 @@
-name,LGV Generic GHGP other regions
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of Fuel,fuelType,TEXT,true,true,,,,
 CO2 per distance,kgCO2PerMile,DECIMAL,true,false,kg,mi,,

--- a/transport/lgv/generic/ghgp/lightgoods/us/biomassfuel/itemdef.csv
+++ b/transport/lgv/generic/ghgp/lightgoods/us/biomassfuel/itemdef.csv
@@ -1,5 +1,3 @@
-name,LGV Generic GHGP US biomass fuel
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of Fuel,fuelType,TEXT,true,true,,,,
 CO2 per distance,kgCO2PerMile,DECIMAL,true,false,kg,mi,,

--- a/transport/lgv/generic/ghgp/lightgoods/us/itemdef.csv
+++ b/transport/lgv/generic/ghgp/lightgoods/us/itemdef.csv
@@ -1,5 +1,3 @@
-name,LGV Generic GHGP US
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of Fuel,fuelType,TEXT,true,true,,,,
 CO2 per distance,kgCO2PerMile,DECIMAL,true,false,kg,mi,,

--- a/transport/lgv/generic/ipcc/europe/itemdef.csv
+++ b/transport/lgv/generic/ipcc/europe/itemdef.csv
@@ -1,5 +1,3 @@
-name,IPCC European Heavy Duty Truck
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,fuel,TEXT,true,true,,,,
 Emissions control technology,technology,TEXT,true,true,,,,

--- a/transport/lgv/generic/ipcc/us/alternativefuels/itemdef.csv
+++ b/transport/lgv/generic/ipcc/us/alternativefuels/itemdef.csv
@@ -1,5 +1,3 @@
-name,IPCC US Heavy Duty Truck alternative fuel
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,fuel,TEXT,true,true,,,,
 Emissions factor type,factorType,TEXT,true,true,,,,

--- a/transport/lgv/generic/ipcc/us/conventionalfuels/itemdef.csv
+++ b/transport/lgv/generic/ipcc/us/conventionalfuels/itemdef.csv
@@ -1,5 +1,3 @@
-name,IPCC US Heavy Duty Truck conventional fuel
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,fuel,TEXT,true,true,,,,
 Emissions control technology,technology,TEXT,true,true,,,,

--- a/transport/lgv/generic/itemdef.csv
+++ b/transport/lgv/generic/itemdef.csv
@@ -1,5 +1,3 @@
-name,Car Generic
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel,fuel,TEXT,true,true,,,,
 Size,size,TEXT,true,true,,,,

--- a/transport/metadata/itemdef.csv
+++ b/transport/metadata/itemdef.csv
@@ -1,5 +1,3 @@
-name,Transport metadata
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Air con usage,airConUsage,TEXT,false,false,,,,
 Car share,carShare,TEXT,false,false,,,,

--- a/transport/minibus/generic/itemdef.csv
+++ b/transport/minibus/generic/itemdef.csv
@@ -1,5 +1,3 @@
-name,Car Generic
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel,fuel,TEXT,true,true,,,,
 Size,size,TEXT,true,true,,,,

--- a/transport/motorcycle/generic/defra/itemdef.csv
+++ b/transport/motorcycle/generic/defra/itemdef.csv
@@ -1,5 +1,3 @@
-name,Motorcycle Generic DEFRA 
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel,fuel,TEXT,true,true,,,,
 Size,size,TEXT,true,true,,,,

--- a/transport/motorcycle/generic/ghgp/other/itemdef.csv
+++ b/transport/motorcycle/generic/ghgp/other/itemdef.csv
@@ -1,5 +1,3 @@
-name,Motorbike Generic GHGP other regions
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of HDV,vehicleType,TEXT,true,true,,,,
 CO2 per distance,kgCO2PerMile,DECIMAL,true,false,kg,mi,,

--- a/transport/motorcycle/generic/ghgp/us/itemdef.csv
+++ b/transport/motorcycle/generic/ghgp/us/itemdef.csv
@@ -1,5 +1,3 @@
-name,Motorbike Generic GHGP US
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of HDV,vehicleType,TEXT,true,true,,,,
 CO2 per distance,kgCO2PerMile,DECIMAL,true,false,kg,mi,,

--- a/transport/motorcycle/generic/ipcc/europe/itemdef.csv
+++ b/transport/motorcycle/generic/ipcc/europe/itemdef.csv
@@ -1,5 +1,3 @@
-name,IPCC European Motorcycle
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,fuel,TEXT,true,true,,,,
 Emissions control technology,technology,TEXT,true,true,,,,

--- a/transport/motorcycle/generic/ipcc/us/conventionalfuels/itemdef.csv
+++ b/transport/motorcycle/generic/ipcc/us/conventionalfuels/itemdef.csv
@@ -1,5 +1,3 @@
-name,IPCC US Motorcycle conventional fuel
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,fuel,TEXT,true,true,,,,
 Emissions control technology,technology,TEXT,true,true,,,,

--- a/transport/motorcycle/generic/itemdef.csv
+++ b/transport/motorcycle/generic/itemdef.csv
@@ -1,5 +1,3 @@
-name,Motorcycle Generic
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel,fuel,TEXT,true,true,,,,
 Size,size,TEXT,true,true,,,,

--- a/transport/other/itemdef.csv
+++ b/transport/other/itemdef.csv
@@ -1,5 +1,3 @@
-name,Transport Other
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Source,source,TEXT,true,false,,,,

--- a/transport/plane/generic/airports/all/codes/itemdef.csv
+++ b/transport/plane/generic/airports/all/codes/itemdef.csv
@@ -1,5 +1,3 @@
-name,Major airport codes
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 IATA code,IATACode,TEXT,true,true,,,,
 Country,country,TEXT,true,false,,,,

--- a/transport/plane/generic/airports/all/countries/itemdef.csv
+++ b/transport/plane/generic/airports/all/countries/itemdef.csv
@@ -1,5 +1,3 @@
-name,Major airports
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Country,country,TEXT,true,true,,,,
 Full name,fullName,TEXT,true,false,,,,

--- a/transport/plane/generic/airports/codes/itemdef.csv
+++ b/transport/plane/generic/airports/codes/itemdef.csv
@@ -1,5 +1,3 @@
-name,Major airport codes
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 IATA code,IATACode,TEXT,true,true,,,,
 Airport name,airportName,TEXT,true,false,,,,

--- a/transport/plane/generic/airports/countries/itemdef.csv
+++ b/transport/plane/generic/airports/countries/itemdef.csv
@@ -1,5 +1,3 @@
-name,Major airports
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Country,country,TEXT,true,true,,,,
 Airport name,airportName,TEXT,true,true,,,,

--- a/transport/plane/generic/defra/itemdef.csv
+++ b/transport/plane/generic/defra/itemdef.csv
@@ -1,5 +1,3 @@
-name,Plane Generic DEFRA
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Passenger class,passengerClass,TEXT,true,true,,,,

--- a/transport/plane/generic/distance/itemdef.csv
+++ b/transport/plane/generic/distance/itemdef.csv
@@ -1,5 +1,3 @@
-name,planeDistance
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Cruising,cruising,DECIMAL,false,false,kg,km,0.10462818336163,
 Distance,distance,DECIMAL,false,false,km,,,

--- a/transport/plane/generic/freight/defra/itemdef.csv
+++ b/transport/plane/generic/freight/defra/itemdef.csv
@@ -1,5 +1,3 @@
-name,Plane Freight DEFRA
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 kgCO2 Per Tonne Km,kgCO2PerTonneKm,DECIMAL,true,false,,,,

--- a/transport/plane/generic/freight/ghgp/other/itemdef.csv
+++ b/transport/plane/generic/freight/ghgp/other/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGP other regional plane freight
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Flight type,type,TEXT,true,true,,,,
 CO2 per weight distance,kgCO2PerTonneKm,DECIMAL,true,false,,,,

--- a/transport/plane/generic/freight/ghgp/us/itemdef.csv
+++ b/transport/plane/generic/freight/ghgp/us/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGP plane freight US
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Flight type,type,TEXT,true,true,,,,
 CO2 per weight distance,kgCO2PerTonneKm,DECIMAL,true,false,,,,

--- a/transport/plane/generic/freight/itemdef.csv
+++ b/transport/plane/generic/freight/itemdef.csv
@@ -1,5 +1,3 @@
-name,Plane Freight
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 CO2,CO2,DECIMAL,true,false,kg,km*kg,,
 Distance,distance,DECIMAL,false,false,km,,,

--- a/transport/plane/generic/itemdef.csv
+++ b/transport/plane/generic/itemdef.csv
@@ -1,5 +1,3 @@
-name,Plane Generic
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Size,size,TEXT,true,true,,,,

--- a/transport/plane/generic/passengerclass/itemdef.csv
+++ b/transport/plane/generic/passengerclass/itemdef.csv
@@ -1,5 +1,3 @@
-name,Plane Class
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Passenger class,passengerClass,TEXT,true,true,,,,

--- a/transport/plane/specific/jet/itemdef.csv
+++ b/transport/plane/specific/jet/itemdef.csv
@@ -1,5 +1,3 @@
-name,Jet aircraft
-algFile,default.js
 name,path,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Aircraft name,aircraft,TEXT,true,true,,,,
 Take off fuel consumption,massFuelTakeOff,DECIMAL,true,false,kg,,,

--- a/transport/plane/specific/military/ipcc/itemdef.csv
+++ b/transport/plane/specific/military/ipcc/itemdef.csv
@@ -1,5 +1,3 @@
-name,IPCC military aircraft
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Aircraft type,type,TEXT,true,true,,,,
 Fuel flow,volumeFuelPerTime,DECIMAL,true,false,L,min,,

--- a/transport/plane/specific/military/itemdef.csv
+++ b/transport/plane/specific/military/itemdef.csv
@@ -1,5 +1,3 @@
-name,Military aircraft
-algFile,default.js
 name,path,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Aircraft type,type,TEXT,true,true,,,,
 Aircraft subtype,subtype,TEXT,true,true,,,,

--- a/transport/plane/specific/turboprop/itemdef.csv
+++ b/transport/plane/specific/turboprop/itemdef.csv
@@ -1,5 +1,3 @@
-name,Turboprop aircraft
-algFile,default.js
 name,path,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Aircraft name,aircraft,TEXT,true,true,,,,
 232 km taxi out fuel consumption,massFuelTaxiOut232km,DECIMAL,true,false,kg,,,

--- a/transport/ship/generic/defra/itemdef.csv
+++ b/transport/ship/generic/defra/itemdef.csv
@@ -1,5 +1,3 @@
-name,Ship Generic DEFRA
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 kgCO2 Per Passenger Km,kgCO2PerKmPassenger,DECIMAL,true,false,,,,

--- a/transport/ship/generic/freight/defra/itemdef.csv
+++ b/transport/ship/generic/freight/defra/itemdef.csv
@@ -1,5 +1,3 @@
-name,Shipping Freight DEFRA
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Typical Vessel Deadweight,typicalVesselDeadweight,TEXT,true,false,t,,,

--- a/transport/ship/generic/freight/ghgp/other/itemdef.csv
+++ b/transport/ship/generic/freight/ghgp/other/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGP other regional ship freight
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of vessel,type,TEXT,true,true,,,,
 Vessel size,size,TEXT,true,true,,,,

--- a/transport/ship/generic/freight/ghgp/us/itemdef.csv
+++ b/transport/ship/generic/freight/ghgp/us/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGP ship freight US
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of vessel,type,TEXT,true,true,,,,
 Vessel size,size,TEXT,true,true,,,,

--- a/transport/ship/generic/freight/itemdef.csv
+++ b/transport/ship/generic/freight/itemdef.csv
@@ -1,5 +1,3 @@
-name,Ship Freight
-algFile,algorithm.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 CO2,CO2,DECIMAL,true,false,kg,km*kg,,
 Source,source,TEXT,true,false,,,,

--- a/transport/ship/generic/itemdef.csv
+++ b/transport/ship/generic/itemdef.csv
@@ -1,5 +1,3 @@
-name,Ship Generic
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 kgCO2 Per Passenger Km,kgCO2PerKmPassenger,DECIMAL,true,false,,,,

--- a/transport/taxi/generic/defra/itemdef.csv
+++ b/transport/taxi/generic/defra/itemdef.csv
@@ -1,5 +1,3 @@
-name,Taxi DEFRA
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Assumed Occupancy,assumedOccupancy,DECIMAL,true,false,,,,

--- a/transport/taxi/generic/ghgp/us/perPassenger/itemdef.csv
+++ b/transport/taxi/generic/ghgp/us/perPassenger/itemdef.csv
@@ -1,5 +1,3 @@
-name,Taxi GHGP per passenger US
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of vehicle,type,TEXT,true,true,,,,
 CO2 per passenger distance,kgCO2PerPassengerMile,DECIMAL,true,false,kg,mi,,

--- a/transport/taxi/generic/itemdef.csv
+++ b/transport/taxi/generic/itemdef.csv
@@ -1,5 +1,3 @@
-name,Taxi Generic
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 kgCO2 Per Km,kgCO2PerKm,DECIMAL,true,false,,,,

--- a/transport/taxi/generic/perpassenger/itemdef.csv
+++ b/transport/taxi/generic/perpassenger/itemdef.csv
@@ -1,5 +1,3 @@
-name,Taxi Generic Per Passenger
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 kgCO2 Per Passenger Km,kgCO2PerKmPassenger,DECIMAL,true,false,,,,

--- a/transport/train/generic/defra/itemdef.csv
+++ b/transport/train/generic/defra/itemdef.csv
@@ -1,5 +1,3 @@
-name,Train Generic DEFRA
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 kgCO2 Per Passenger Km,kgCO2PerKmPassenger,DECIMAL,true,false,,,,

--- a/transport/train/generic/freight/defra/itemdef.csv
+++ b/transport/train/generic/freight/defra/itemdef.csv
@@ -1,5 +1,3 @@
-name,Train Freight DEFRA
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel,fuel,TEXT,true,true,,,,
 kgCO2 Per Tonne Km,kgCO2PerTonneKm,DECIMAL,true,false,,,,

--- a/transport/train/generic/freight/ghgp/other/itemdef.csv
+++ b/transport/train/generic/freight/ghgp/other/itemdef.csv
@@ -1,5 +1,3 @@
-name,Freight transport GHGP
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of train,type,TEXT,true,true,,,,
 Train sub-type,subtype,TEXT,true,true,,,,

--- a/transport/train/generic/freight/ghgp/us/itemdef.csv
+++ b/transport/train/generic/freight/ghgp/us/itemdef.csv
@@ -1,5 +1,3 @@
-name,GHGP train freight US
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of train,type,TEXT,true,true,,,,
 Train sub-type,subtype,TEXT,true,true,,,,

--- a/transport/train/generic/ghgp/us/perpassenger/itemdef.csv
+++ b/transport/train/generic/ghgp/us/perpassenger/itemdef.csv
@@ -1,5 +1,3 @@
-name,Train GHGP per passenger US
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type of vehicle,type,TEXT,true,true,,,,
 CO2 per passenger distance,kgCO2PerPassengerMile,DECIMAL,true,false,kg,mi,,

--- a/transport/train/generic/itemdef.csv
+++ b/transport/train/generic/itemdef.csv
@@ -1,5 +1,3 @@
-name,Train Generic
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 kgCO2 Per Passenger Km,kgCO2PerKmPassenger,DECIMAL,true,false,,,,

--- a/transport/train/route/itemdef.csv
+++ b/transport/train/route/itemdef.csv
@@ -1,5 +1,3 @@
-name,Train Route
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Type,type,TEXT,true,true,,,,
 Source,source,TEXT,true,false,,,,

--- a/transport/train/route/stations/uk/itemdef.csv
+++ b/transport/train/route/stations/uk/itemdef.csv
@@ -1,5 +1,3 @@
-name,Train Stations UK
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 name,name,TEXT,true,true,,,,
 Code,code,TEXT,true,false,,,,

--- a/transport/train/specific/diesel/itemdef.csv
+++ b/transport/train/specific/diesel/itemdef.csv
@@ -1,5 +1,3 @@
-name,Train specific diesel
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Region,region,TEXT,true,true,,,,
 Train type,type,TEXT,true,true,,,,

--- a/transport/train/specific/electric/itemdef.csv
+++ b/transport/train/specific/electric/itemdef.csv
@@ -1,5 +1,3 @@
-name,Train specific electric
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Region,region,TEXT,true,true,,,,
 Train type,type,TEXT,true,true,,,,

--- a/transport/van/generic/defra/itemdef.csv
+++ b/transport/van/generic/defra/itemdef.csv
@@ -1,5 +1,3 @@
-name,Van Generic DEFRA 
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel,fuel,TEXT,true,true,,,,
 kgCO2 Per Km,kgCO2PerKm,DECIMAL,true,false,,,,

--- a/transport/van/generic/freight/defra/itemdef.csv
+++ b/transport/van/generic/freight/defra/itemdef.csv
@@ -1,5 +1,3 @@
-name,Light Goods Freight DEFRA
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel,fuel,TEXT,true,true,,,,
 Vehicle Size,size,TEXT,true,true,,,,

--- a/transport/van/generic/ipcc/europe/itemdef.csv
+++ b/transport/van/generic/ipcc/europe/itemdef.csv
@@ -1,5 +1,3 @@
-name,IPCC European Light Duty Truck
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,fuel,TEXT,true,true,,,,
 Emissions control technology,technology,TEXT,true,true,,,,

--- a/transport/van/generic/ipcc/us/alternativefuels/itemdef.csv
+++ b/transport/van/generic/ipcc/us/alternativefuels/itemdef.csv
@@ -1,5 +1,3 @@
-name,IPCC US Light Goods Truck alternative fuel
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,fuel,TEXT,true,true,,,,
 Emissions factor type,factorType,TEXT,true,true,,,,

--- a/transport/van/generic/ipcc/us/conventionalfuels/itemdef.csv
+++ b/transport/van/generic/ipcc/us/conventionalfuels/itemdef.csv
@@ -1,5 +1,3 @@
-name,IPCC US Light Goods Truck conventional fuel
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel type,fuel,TEXT,true,true,,,,
 Emissions control technology,technology,TEXT,true,true,,,,

--- a/transport/van/generic/itemdef.csv
+++ b/transport/van/generic/itemdef.csv
@@ -1,5 +1,3 @@
-name,Car Generic
-algFile,default.js
 name,path,type,isDataItemValue,isDrillDown,unit,perUnit,default,choices
 Fuel,fuel,TEXT,true,true,,,,
 Size,size,TEXT,true,true,,,,


### PR DESCRIPTION
These files contain definitions for what can be found in the respective
`data.csv` files. Their first two lines, however, do not conform to the
same number of columns or the same format as the rest of those files.

In the first line, we would find a title for the dataset in question. We
can also find that in the README for each dataset. The second line
contains the file that has the algorithm for each dataset. It's always
the same: `default.js`. Therefore, we think we can do without those two
lines.

This was done using the following sh-fu:
    ```sh
    find . -name itemdef.csv | xargs sed -i '1,2d'
    ```
