### PR TITLE
Fix CSV files with subscript HTML tags

### DIFF
--- a/business/energy/stationaryCombustion/crc/data.csv
+++ b/business/energy/stationaryCombustion/crc/data.csv
@@ -25,7 +25,7 @@
 "solid smokeless fuel",,2810.0000,,"mass",,"http://www.decc.gov.uk/en/content/cms/what_we_do/lc_uk/crc/user_guidance/user_guidance.aspx : Table of Conversion Factors"
 "sour gas",0.2397,,,"energy",,"http://www.decc.gov.uk/en/content/cms/what_we_do/lc_uk/crc/user_guidance/user_guidance.aspx : Table of Conversion Factors"
 "waste",,275.0000,,"mass",,"http://www.decc.gov.uk/en/content/cms/what_we_do/lc_uk/crc/user_guidance/user_guidance.aspx : Table of Conversion Factors"
-"waste oils"<sub>3026</sub>"mass",,"http://www.decc.gov.uk/en/content/cms/what_we_do/lc_uk/crc/user_guidance/user_guidance.aspx : Table of Conversion Factors"
+"waste oils",,3026,,"mass",,"http://www.decc.gov.uk/en/content/cms/what_we_do/lc_uk/crc/user_guidance/user_guidance.aspx : Table of Conversion Factors"
 "waste solvents",,1613.0000,,"mass",,"http://www.decc.gov.uk/en/content/cms/what_we_do/lc_uk/crc/user_guidance/user_guidance.aspx : Table of Conversion Factors"
 "refinery miscellaneous",0.2450,,,"energy",,"http://www.decc.gov.uk/en/content/cms/consultations/crc/crc.aspx : Consultation on Draft Order to Implement the Carbon Reduction Commitment"
 "electricity",0.5410,,,"energy",,"http://www.decc.gov.uk/en/content/cms/what_we_do/lc_uk/crc/user_guidance/user_guidance.aspx : Table of Conversion Factors"

--- a/business/waste/water/industrial/industryfactors/data.csv
+++ b/business/waste/water/industrial/industryfactors/data.csv
@@ -1,7 +1,7 @@
 industry,volumeWasteWaterPerMassProduction,massOrganicPerVolumeWasteWater,units,source
 alcohol refining,24,11,,http://www.ipcc-nggip.iges.or.jp/public/2006gl/pdf/5_Volume5/V5_6_Ch6_Wastewater.pdf
 beer and malt,6.3,2.9,,http://www.ipcc-nggip.iges.or.jp/public/2006gl/pdf/5_Volume5/V5_6_Ch6_Wastewater.pdf
-coffee<sub>9</sub>http://www.ipcc-nggip.iges.or.jp/public/2006gl/pdf/5_Volume5/V5_6_Ch6_Wastewater.pdf
+coffee,,9,,http://www.ipcc-nggip.iges.or.jp/public/2006gl/pdf/5_Volume5/V5_6_Ch6_Wastewater.pdf
 dairy products,7,2.7,,http://www.ipcc-nggip.iges.or.jp/public/2006gl/pdf/5_Volume5/V5_6_Ch6_Wastewater.pdf
 fish processing,,2.5,,http://www.ipcc-nggip.iges.or.jp/public/2006gl/pdf/5_Volume5/V5_6_Ch6_Wastewater.pdf
 meat and poultry,13,4.1,,http://www.ipcc-nggip.iges.or.jp/public/2006gl/pdf/5_Volume5/V5_6_Ch6_Wastewater.pdf

--- a/home/waste/lifecyclewaste/data.csv
+++ b/home/waste/lifecyclewaste/data.csv
@@ -15,6 +15,6 @@
 "glass","525","840","-315","0","5",,,"10",,"http://www.defra.gov.uk/environment/business/reporting/conversion-factors.htm"
 "other waste","2860","2860","-259",,"97","-13","7","81",,"http://www.defra.gov.uk/environment/business/reporting/conversion-factors.htm"
 "batteries",,,-490,,75,75,75,75,,"http://www.defra.gov.uk/environment/business/reporting/conversion-factors.htm"
-"small waste electrical and electronic equipment",,,-580,,,<sub>470</sub>"http://www.defra.gov.uk/environment/business/reporting/conversion-factors.htm"
-"large waste electrical and electronic equipment",,,-710,,,<sub>540</sub>"http://www.defra.gov.uk/environment/business/reporting/conversion-factors.htm"
+"small waste electrical and electronic equipment",,,-580,,,,,470,,"http://www.defra.gov.uk/environment/business/reporting/conversion-factors.htm"
+"large waste electrical and electronic equipment",,,-710,,,,,540,,"http://www.defra.gov.uk/environment/business/reporting/conversion-factors.htm"
 "tyres",510,3410,-2900,-20,-1500,,,,,"http://www.defra.gov.uk/environment/business/reporting/conversion-factors.htm"

--- a/transport/ghgp/vehicle/other/data.csv
+++ b/transport/ghgp/vehicle/other/data.csv
@@ -1,5 +1,5 @@
 "type","fuel","emissionStandard","distancePerVolume","massCO2PerDistance","massBiogenicCO2PerDistance","units","source"
-"bus","ethanol"<sub>5</sub>1.112,,"http://www.ghgprotocol.org/calculation-tools/all-tools"
+"bus","ethanol",,5,,1.112,,"http://www.ghgprotocol.org/calculation-tools/all-tools"
 "bus","diesel",,3.7,2.73810810810811,,,"http://www.ghgprotocol.org/calculation-tools/all-tools"
 "bus","gasoline",,5,1.7197469982,,,"http://www.ghgprotocol.org/calculation-tools/all-tools"
 "passenger car","gasoline","1984-1993",22.5,0.3821659996,,,"http://www.ghgprotocol.org/calculation-tools/all-tools"


### PR DESCRIPTION
When converting the creole documentation to Markdown, we substituted the
pattern `,,.*?,,` with `<sub>$1</sub>` in order to get proper subscripts
in the Markdown files. Unfortunately we also applied that
search-and-replace to CSV files which also exhibit this pattern, making
the CSV files invalid. This commit reverts that change in our data CSVs.