### PR TITLE
Parse itemdefs and data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+node_modules
+package-lock.json
+yarn.lock

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  presets: [
+    [
+      "@babel/preset-env",
+      {
+        targets: {
+          node: "current"
+        }
+      }
+    ]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "dAMEE - Distributed Avoid Mass Extinction Engine",
+  "version": "0.0.1",
+  "description": "",
+  "scripts": {
+    "test": "jest",
+    "build": "babel src data --out-dir dist"
+  },
+  "keywords": ["tgwf", "sustainability", "climate" ,"opendata"],
+  "contributors": [
+    "AMEE UK Limited",
+    "Andrew Berkeley",
+    "Chris Adams <chris@productscience.net>",
+    "David Keen",
+    "Martin Meyerhoff <mamhoff@gmail.com>"
+  ],
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {
+    "@babel/cli": "^7.5.0",
+    "@babel/core": "^7.5.4",
+    "@babel/preset-env": "^7.5.4",
+    "fs": "0.0.1-security",
+    "jest": "^24.8.0",
+    "neat-csv": "^5.1.0",
+    "np": "^5.0.3"
+  }
+}

--- a/src/convertData.js
+++ b/src/convertData.js
@@ -22,3 +22,22 @@ export async function getItemDefinitions(path) {
   })
   return returnValue;
 }
+
+export async function getData(path) {
+  const itemDefinitions = await getItemDefinitions(path)
+  const csvData = fs.readFileSync(path + "/data.csv", "utf8");
+  const parsedCsv = await neatCsv(csvData, {
+    mapValues: ({ header, index, value }) => {
+      if (value === "") {
+        return null;
+      } else if (header.startsWith('is')) {
+        return value == "true"
+      } else if (itemDefinitions[header].type === "DECIMAL") {
+        return parseFloat(value)
+      } else {
+        return value.trim()
+      }
+    }
+  })
+  return parsedCsv;
+}

--- a/src/convertData.js
+++ b/src/convertData.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const neatCsv = require('neat-csv');
+
+export async function getItemDefinitions(path) {
+  const csvData = fs.readFileSync(path + "/itemdef.csv", "utf8");
+  const parsedCsv = await neatCsv(csvData, {
+    mapValues: ({ header, index, value }) => {
+      if (value === "") {
+        return null;
+      } else if (header.startsWith('is')) {
+        return value == "true"
+      } else {
+        return value
+      }
+    }
+  })
+  const returnValue = {}
+  parsedCsv.forEach((element) => {
+    returnValue[element.path] = element
+  })
+  return returnValue;
+}

--- a/src/convertData.js
+++ b/src/convertData.js
@@ -9,6 +9,8 @@ export async function getItemDefinitions(path) {
         return null;
       } else if (header.startsWith('is')) {
         return value == "true"
+      } else if (header === "choices") {
+        return value.split('|')
       } else {
         return value
       }

--- a/test/convertData.test.js
+++ b/test/convertData.test.js
@@ -18,3 +18,20 @@ test('works on planet/greenhousegases/gwp', async () => {
     }
   )
 })
+
+test('works on business/waste/combustion/industrial', async () => {
+  const data = await convertData.getItemDefinitions('business/waste/combustion/industrial');
+  expect(data['includeAllCarbon']).toMatchObject(
+    {
+      "name": "Include all carbon",
+      "path": "includeAllCarbon",
+      "type": "TEXT",
+      "isDataItemValue": false,
+      "isDrillDown": false,
+      "unit": null,
+      "perUnit": null,
+      "default": 'false',
+      "choices": ['true', 'false']
+    }
+  )
+})

--- a/test/convertData.test.js
+++ b/test/convertData.test.js
@@ -1,0 +1,20 @@
+"use strict";
+
+const convertData = require('../src/convertData');
+
+test('works on planet/greenhousegases/gwp', async () => {
+  const data = await convertData.getItemDefinitions('planet/greenhousegases/gwp');
+  expect(data['gas']).toMatchObject(
+    {
+      "name": "Gas",
+      "path": "gas",
+      "type": "TEXT",
+      "isDataItemValue": true,
+      "isDrillDown": true,
+      "unit": null,
+      "perUnit": null,
+      "default": null,
+      "choices": null
+    }
+  )
+})

--- a/test/convertData.test.js
+++ b/test/convertData.test.js
@@ -2,36 +2,59 @@
 
 const convertData = require('../src/convertData');
 
-test('works on planet/greenhousegases/gwp', async () => {
-  const data = await convertData.getItemDefinitions('planet/greenhousegases/gwp');
-  expect(data['gas']).toMatchObject(
-    {
-      "name": "Gas",
-      "path": "gas",
-      "type": "TEXT",
-      "isDataItemValue": true,
-      "isDrillDown": true,
-      "unit": null,
-      "perUnit": null,
-      "default": null,
-      "choices": null
-    }
-  )
+describe("getItemDefinitions", () => {
+  test('works on planet/greenhousegases/gwp', async () => {
+    const data = await convertData.getItemDefinitions('planet/greenhousegases/gwp');
+    expect(data['gas']).toMatchObject(
+      {
+        "name": "Gas",
+        "path": "gas",
+        "type": "TEXT",
+        "isDataItemValue": true,
+        "isDrillDown": true,
+        "unit": null,
+        "perUnit": null,
+        "default": null,
+        "choices": null
+      }
+    )
+  })
+
+  test('works on business/waste/combustion/industrial', async () => {
+    const data = await convertData.getItemDefinitions('business/waste/combustion/industrial');
+    expect(data['includeAllCarbon']).toMatchObject(
+      {
+        "name": "Include all carbon",
+        "path": "includeAllCarbon",
+        "type": "TEXT",
+        "isDataItemValue": false,
+        "isDrillDown": false,
+        "unit": null,
+        "perUnit": null,
+        "default": 'false',
+        "choices": ['true', 'false']
+      }
+    )
+  })
 })
 
-test('works on business/waste/combustion/industrial', async () => {
-  const data = await convertData.getItemDefinitions('business/waste/combustion/industrial');
-  expect(data['includeAllCarbon']).toMatchObject(
-    {
-      "name": "Include all carbon",
-      "path": "includeAllCarbon",
-      "type": "TEXT",
-      "isDataItemValue": false,
-      "isDrillDown": false,
-      "unit": null,
-      "perUnit": null,
-      "default": 'false',
-      "choices": ['true', 'false']
-    }
-  )
+describe("getData", () => {
+  it("works on planet/greenhousegases/gwp", async () => {
+    const data = await convertData.getData('planet/greenhousegases/gwp');
+    expect(data.find((elem) => elem.gas == 'SF6')).toMatchObject(
+      {
+        "GWP": 23900.000,
+        "formula": "SF6",
+        "gas": "SF6",
+        "gwp_4AR_100": 22800.000,
+        "gwp_4AR_20": 16300.000,
+        "gwp_4AR_500": 32600.000,
+        "gwp_SAR_100": 23900.000,
+        "name": "sulphur hexafluoride",
+        "residenceTime": 3200.000,
+        "source": "http://www.ipcc.ch/pdf/assessment-report/ar4/wg1/ar4-wg1-chapter2.pdf",
+        "units": null
+      }
+    )
+  })
 })


### PR DESCRIPTION
This adds a package.json and the appropriate `.gitignore` to setup using JS. 
Code lives in the `src` directory, tests in the `test` directory. In order to run the specs, run `yarn jest`.

The main feature of this PR is two JS functions that take a directory name from the dataset and parse the `data.csv` and `itemdef.csv`. The final goal of this is to be able to provide a loadable JSON for each dataset that works well with the `default.js`.
